### PR TITLE
fix: transitive deps

### DIFF
--- a/odoo_venv/main.py
+++ b/odoo_venv/main.py
@@ -279,7 +279,6 @@ def create_odoo_venv(  # noqa: C901
             "uv",
             "pip",
             "install",
-            "--no-deps",
             "-r",
             tmp_path,
         ]


### PR DESCRIPTION
- case I faced: zeep was installed but not cached-property

<img width="1552" height="707" alt="image" src="https://github.com/user-attachments/assets/563f3153-567d-4805-893d-8c48ab043a1a" />


- any cons?