### PR TITLE
fix(cli): prevent Typer from collapsing 'create' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This command creates a virtual environment for Odoo 17.0 with the following spec
 
 For recurring configurations, you can define presets in a `presets.toml` file, in `~/.local/share/odoo-venv/`.
 
-There are 4 out-of-box presets: local, demo, project, ci (see [src/odoo_venv/assets/presets.toml](src/odoo_venv/assets/presets.toml))
+There are 4 out-of-box presets: local, demo, project, ci (see [odoo_venv/assets/presets.toml](odoo_venv/assets/presets.toml))
 
 **Example:**
 

--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -44,6 +44,11 @@ def preset_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
     return value
 
 
+@app.callback()
+def main_callback():
+    pass
+
+
 @app.command()
 def create(
     ctx: typer.Context,


### PR DESCRIPTION
When a Typer app has only one command, it collapses it into the main app entry point.
This causes `odoo-venv create 18.0` to fail, as 'create' is interpreted as the
version argument and '18.0' as an unexpected extra argument.

This commit adds a callback to the Typer app to force the subcommand structure,
ensuring `odoo-venv create ...` works as expected.
