### PR TITLE
feat(cli): add -V/--version flag to display version

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from importlib.metadata import version
 from pathlib import Path
 from typing import Annotated
 
@@ -44,8 +45,25 @@ def preset_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
     return value
 
 
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"odoo-venv {version('odoo-venv')}")
+        raise typer.Exit()
+
+
 @app.callback()
-def main_callback():
+def main_callback(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-V",
+            callback=version_callback,
+            is_eager=True,
+            help="Display the odoo-venv version.",
+        ),
+    ] = False,
+):
     pass
 
 


### PR DESCRIPTION
## Summary
- Adds `-V` / `--version` option to display the odoo-venv version
- Uses `importlib.metadata.version()` to dynamically retrieve the package version
- Implements as an eager callback to exit immediately after displaying version

## Test plan
- [ ] Run `odoo-venv --version` and verify version is displayed
- [ ] Run `odoo-venv -V` and verify version is displayed
- [ ] Verify other commands still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)