### PR TITLE
feat: prioritize extra requirements

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -50,7 +50,8 @@ greenlet==1.1.2; sys_platform != 'win32' and python_version == '3.10'
 """
 extra_requirement = """
 gevent==22.10.2; sys_platform != 'win32' and python_version == '3.10',
-greenlet==2.0.2; sys_platform != 'win32' and python_version == '3.10'
+greenlet==2.0.2; sys_platform != 'win32' and python_version == '3.10',
+setuptools<58.0.0
 """
 
 # always ignore those exotic requirements unless explicitely added


### PR DESCRIPTION
Odoo 13.0 requires vatnumber==1.2.0 that still needs use_2to3. Meanwhile [setuptools>=58.0.0 breaks support for
use_2to3](https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2) so we need to fall back to setuptools<58.0.0. This commit prioritizes installing extra requirements to support that.