### PR TITLE
feat: add --project-dir option to create command

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -1,9 +1,12 @@
+import re
 from dataclasses import asdict
 from importlib.metadata import version
 from pathlib import Path
 from typing import Annotated
 
 import typer
+from odoo_addons_path import get_addons_path
+from odoo_addons_path.main import _detect_codebase_layout
 
 from odoo_venv.exceptions import PresetNotFoundError
 from odoo_venv.main import create_odoo_venv
@@ -47,6 +50,30 @@ def preset_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
     return value
 
 
+def _get_odoo_version_from_release(odoo_dir: Path) -> str | None:
+    """Read the Odoo version (e.g. '18.0') from ``odoo/release.py``."""
+    release_py = odoo_dir / "odoo" / "release.py"
+    if not release_py.is_file():
+        return None
+    content = release_py.read_text()
+    match = re.search(r"version_info\s*=\s*\((\d+),\s*(\d+)", content)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+    return None
+
+
+def project_dir_callback(ctx: typer.Context, param: typer.CallbackParam, value: str | None):
+    if not value:
+        return None
+
+    # Auto-apply "project" preset if no preset was explicitly set
+    if not ctx.default_map:
+        preset_callback(ctx, param, "project")
+
+    ctx.ensure_object(dict)["project_dir"] = value
+    return value
+
+
 def version_callback(value: bool):
     if value:
         typer.echo(f"odoo-venv {version('odoo-venv')}")
@@ -70,9 +97,11 @@ def main_callback(
 
 
 @app.command()
-def create(
+def create(  # noqa: C901
     ctx: typer.Context,
-    odoo_version: Annotated[str, typer.Argument(help="Odoo version, e.g: 18.0")],
+    odoo_version: Annotated[
+        str | None, typer.Argument(help="Odoo version, e.g: 18.0. Inferred from --project-dir if omitted.")
+    ] = None,
     python_version: Annotated[
         str | None,
         typer.Option("--python-version", "-p", help="Specify Python version."),
@@ -146,12 +175,49 @@ def create(
             help="Use a preset of options. Preset values can be overriden by other options.",
         ),
     ] = None,
+    project_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--project-dir",
+            callback=project_dir_callback,
+            is_eager=True,
+            help="Path to project directory. Auto-detects --addons-path, --odoo-dir "
+            "via odoo-addons-path and applies --preset=project.",
+        ),
+    ] = None,
 ):
     """Create virtual environment to run Odoo"""
-    if not odoo_dir:
+    # Handle --project-dir: auto-detect addons_path and odoo_dir
+    project_dir_value = ctx.obj.get("project_dir") if ctx.obj else None
+    detected_addons_path = None
+    if project_dir_value:
+        project_dir_path = Path(project_dir_value).expanduser().resolve()
+        detected_paths = _detect_codebase_layout(project_dir_path)
+        detected_addons_path = get_addons_path(project_dir_path)
+
+    # Resolve odoo_dir (before odoo_version, which may be inferred from it)
+    if odoo_dir:
+        odoo_dir_path = Path(odoo_dir).expanduser().resolve()
+    elif project_dir_value and detected_paths.get("odoo_dir"):
+        odoo_dir_path = detected_paths["odoo_dir"][0].parent
+    elif odoo_version:
         odoo_dir_path = Path(f"~/code/odoo/odoo/{odoo_version}").expanduser()
     else:
-        odoo_dir_path = Path(odoo_dir).expanduser().resolve()
+        typer.secho(
+            "error: ODOO_VERSION is required when --project-dir is not used.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    # Infer odoo_version from release.py if not provided
+    if not odoo_version:
+        odoo_version = _get_odoo_version_from_release(odoo_dir_path)
+        if not odoo_version:
+            typer.secho(
+                "error: Could not detect Odoo version from source. Provide ODOO_VERSION explicitly.",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(1)
 
     if not python_version:
         python_version = ODOO_PYTHON_VERSIONS.get(odoo_version)
@@ -164,6 +230,9 @@ def create(
             extra_requirements_list = extra_requirement.split(",")
         else:
             extra_requirements_list = list(extra_requirement)
+
+    if not addons_path and detected_addons_path:
+        addons_path = detected_addons_path
 
     addons_path_list = (
         [str(Path(p.strip()).expanduser().resolve()) for p in addons_path.split(",")] if addons_path else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "typing_extensions",
     "tomli",
     "packaging>=25.0",
+    "odoo-addons-path",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -90,10 +90,24 @@ wheels = [
 ]
 
 [[package]]
+name = "odoo-addons-path"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/7b/4a04973a116e1ef96b9f56f9c49c2080692239988d4efa25322898197629/odoo_addons_path-1.0.1.tar.gz", hash = "sha256:8c9920af7e3ebf4ac530a8a43d717c216d5972253e991dce7cb5819126386074", size = 67459, upload-time = "2026-01-20T04:13:53.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/49/b6cb07ec3956f205eeeeed0d30c5f4ec15397641d11875700ee38e56d78a/odoo_addons_path-1.0.1-py3-none-any.whl", hash = "sha256:b59f6b0c12e2c06d450ec2cede989a0669d518aa11d91be0b4417a6f7f019890", size = 19523, upload-time = "2026-01-20T04:13:51.406Z" },
+]
+
+[[package]]
 name = "odoo-venv"
 version = "1.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "odoo-addons-path" },
     { name = "packaging" },
     { name = "tomli" },
     { name = "typer" },
@@ -114,6 +128,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "odoo-addons-path" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "tomli" },
     { name = "typer" },


### PR DESCRIPTION
## Summary
- Adds `--project-dir` option that uses `odoo-addons-path` to auto-detect `--addons-path`, `--odoo-dir`, and `--preset=project`
- Makes `ODOO_VERSION` optional when `--project-dir` is used — inferred from `odoo/release.py`
- Adds `odoo-addons-path` as a dependency

## Usage

```bash
# Before: all parameters manual
odoo-venv create 18.0 --preset project --odoo-dir /path/to/project/odoo --addons-path "..."

# After: single flag does it all
odoo-venv create --project-dir /path/to/project
```

## Test plan
- [ ] `odoo-venv create --project-dir /path/to/project --dry-run` — auto-detects everything
- [ ] `odoo-venv create 18.0 --project-dir /path --dry-run` — explicit version takes precedence
- [ ] `odoo-venv create --preset local --project-dir /path --dry-run` — explicit preset takes precedence
- [ ] `odoo-venv create --dry-run` — errors with clear message about missing ODOO_VERSION
- [ ] `odoo-venv create 18.0 --dry-run` — existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)