### PR TITLE
fix: scope gevent override to linux in common preset

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -86,8 +86,8 @@ greenlet==1.1.2; sys_platform != 'win32' and python_version == '3.10',
 vatnumber
 """
 extra_requirement = """
-gevent==22.10.2; sys_platform != 'win32' and python_version == '3.10',
-greenlet==2.0.2; sys_platform != 'win32' and python_version == '3.10'
+gevent==22.10.2; sys_platform == 'linux' and python_version == '3.10',
+greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10'
 """
 
 # always ignore those exotic requirements unless explicitely added


### PR DESCRIPTION
Why
The common preset was forcing gevent==22.10.2 and greenlet==2.0.2 on all non-Windows platforms, including macOS, where this override causes installation problems.

What changed
The markers were narrowed from sys_platform != 'win32' to sys_platform == 'linux'.

Result
Linux keeps the Ubuntu/Python 3.10 workaround, while macOS no longer receives the problematic pinned override.