### PR TITLE
feat: support escaped commas in --extra-requirement

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -13,7 +13,7 @@ from odoo_addons_path import (
 from odoo_venv.exceptions import PresetNotFoundError
 from odoo_venv.launcher import create_launcher
 from odoo_venv.main import create_odoo_venv
-from odoo_venv.utils import initialize_presets, load_presets, run_migration
+from odoo_venv.utils import initialize_presets, load_presets, run_migration, split_escaped
 
 app = typer.Typer()
 initialize_presets()
@@ -206,7 +206,7 @@ def create(
     ] = None,
     extra_requirement: Annotated[
         str | None,
-        typer.Option(help="Comma-separated list of extra packages to install."),
+        typer.Option(help="Comma-separated list of extra packages to install. Use \\, for a literal comma."),
     ] = None,
     verbose: Annotated[
         bool,
@@ -262,7 +262,7 @@ def create(
     extra_requirements_list = []
     if extra_requirement:
         if isinstance(extra_requirement, str):
-            extra_requirements_list = extra_requirement.split(",")
+            extra_requirements_list = split_escaped(extra_requirement)
         else:
             extra_requirements_list = list(extra_requirement)
 

--- a/odoo_venv/utils.py
+++ b/odoo_venv/utils.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, fields
@@ -6,6 +7,26 @@ from pathlib import Path
 
 import tomli
 from packaging.version import Version
+
+
+def split_escaped(s: str, sep: str = ",") -> list[str]:
+    """Split *s* on *sep*, honouring backslash-escaped separators.
+
+    Escaped separators (``\\,``) are preserved as literal characters in the
+    resulting items; unescaped separators are used as split points.
+
+    >>> split_escaped("sentry_sdk,requests")
+    ['sentry_sdk', 'requests']
+    >>> split_escaped(r"sentry_sdk>=2.0.0\\,<=2.22.0")
+    ['sentry_sdk>=2.0.0,<=2.22.0']
+    >>> split_escaped(r"a,sentry_sdk>=2.0.0\\,<=2.22.0,b")
+    ['a', 'sentry_sdk>=2.0.0,<=2.22.0', 'b']
+    >>> split_escaped("")
+    ['']
+    """
+    parts = re.split(rf"(?<!\\){re.escape(sep)}", s)
+    return [p.replace(f"\\{sep}", sep) for p in parts]
+
 
 ROOT_PATH = Path("~/.local/share/odoo-venv/").expanduser()
 PRESETS_FILE = "presets.toml"


### PR DESCRIPTION
## Summary

- Adds `split_escaped()` helper in `utils.py` that splits on `,` while honouring `\,` as a literal comma
- Replaces the plain `.split(",")` call for `--extra-requirement` with `split_escaped()`
- Updates the option help text to document the escape syntax

## Usage

```bash
odoo-venv create 18.0 --extra-requirement="requests,sentry_sdk>=2.0.0\,<=2.22.0"
# installs: requests   AND   sentry_sdk>=2.0.0,<=2.22.0
```

## Notes

- Backward compatible: existing comma-separated lists (e.g. `"pkg1,pkg2"`) split identically to before
- Presets are unaffected for normal usage; preset authors can now use `\,` in TOML strings for multi-specifier requirements
- `split_escaped` is covered by doctests (picked up by `make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)