### PR TITLE
ci: cache uv binary in tool-cache to skip GitHub Releases download

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Odoo ${{ matrix.odoo_version }} (Python ${{ matrix.python_version }})
+  test-native:
+    name: Odoo-only | Odoo ${{ matrix.odoo_version }} (Python ${{ matrix.python_version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -72,6 +72,8 @@ jobs:
       - name: Bootstrap
         run: |
           mkdir -p ~/code
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          curl -fsSL https://raw.githubusercontent.com/trobz/local.py/main/bootstrap.sh | bash
           cat > ~/code/config.toml << 'EOF'
           versions = ["${{ matrix.odoo_version }}"]
 
@@ -82,11 +84,8 @@ jobs:
           [repos]
           odoo = ["odoo"]
           EOF
-          # workaround to be able to clone repos without ssh in CI:
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-          curl -fsSL https://raw.githubusercontent.com/trobz/local.py/main/bootstrap.sh | bash
-          tlc --no-newcomer install-tools
-          tlc --no-newcomer init
+          tlc --yes install-tools
+          tlc --yes init
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       # Cache the Odoo source for the day to avoid cloning on every run.
@@ -99,7 +98,7 @@ jobs:
           key: odoo-${{ matrix.odoo_version }}-${{ runner.os }}-${{ env.TODAY }}
 
       - name: Pull repos
-        run: tlc --no-newcomer pull-repos
+        run: tlc --yes pull-repos
 
       - name: Check out odoo-venv
         uses: actions/checkout@v4
@@ -130,3 +129,114 @@ jobs:
             --venv-dir ~/code/venvs/${{ matrix.odoo_version }} \
             --python-version ${{ matrix.python_version }} \
             --create-launcher
+
+  test-oca:
+    name: With OCA modules | Odoo ${{ matrix.odoo_version }} (Python ${{ matrix.python_version }})
+    needs: test-native
+    if: needs.test-native.result == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - odoo_version: "12.0"
+            python_version: "3.7"
+          - odoo_version: "13.0"
+            python_version: "3.7"
+          - odoo_version: "14.0"
+            python_version: "3.8"
+          - odoo_version: "15.0"
+            python_version: "3.8"
+          - odoo_version: "16.0"
+            python_version: "3.10"
+          - odoo_version: "17.0"
+            python_version: "3.10"
+          - odoo_version: "18.0"
+            python_version: "3.10"
+          - odoo_version: "19.0"
+            python_version: "3.10"
+          - odoo_version: "18.0"
+            python_version: "3.12"
+          - odoo_version: "19.0"
+            python_version: "3.12"
+          # master excluded: no all_repos_master.toml in trobz/odoo-addons-repos
+
+    steps:
+      # Cache the uv binary in GitHub Actions tool-cache so setup-uv
+      # finds it and skips downloading from GitHub Releases.
+      - name: Cache uv binary
+        uses: actions/cache@v4
+        with:
+          path: /opt/hostedtoolcache/uv
+          key: uv-binary-${{ runner.os }}-0.10.8
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.10.8"
+          enable-cache: true
+          ignore-empty-workdir: true
+
+      - name: Bootstrap
+        run: |
+          mkdir -p ~/code
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          curl -fsSL https://raw.githubusercontent.com/trobz/local.py/main/bootstrap.sh | bash
+          # use the auto-generated per-version repo list from trobz/odoo-addons-repos
+          curl -fsSL "https://raw.githubusercontent.com/trobz/odoo-addons-repos/main/all_repos_${{ matrix.odoo_version }}.toml" > ~/code/config.toml
+          # append tools section (must come after top-level keys in the downloaded file)
+          cat >> ~/code/config.toml << 'EOF'
+
+          [tools]
+          uv = ["odoo-addons-path"]
+          system_packages = ["postgresql"]
+          EOF
+          tlc --yes install-tools
+          tlc --yes init
+          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      # Combined cache for Odoo source + OCA repos.
+      # Falls back to the Odoo-only cache produced by the test-native job on first run.
+      - name: Cache repos ${{ matrix.odoo_version }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/code/odoo/odoo/${{ matrix.odoo_version }}
+            ~/code/oca/${{ matrix.odoo_version }}
+          key: repos-${{ matrix.odoo_version }}-${{ runner.os }}-${{ env.TODAY }}
+          restore-keys: |
+            odoo-${{ matrix.odoo_version }}-${{ runner.os }}-${{ env.TODAY }}
+
+      - name: Pull repos
+        # Some OCA repos don't have branches for older Odoo versions — accept failures
+        continue-on-error: true
+        run: tlc --yes pull-repos
+
+      - name: Check out odoo-venv
+        uses: actions/checkout@v4
+
+      - name: Install odoo-venv
+        run: uv tool install .
+
+      - name: Install Python ${{ matrix.python_version }} via pyenv
+        if: matrix.python_version == '3.7'
+        run: |
+          curl -fsSL https://pyenv.run | bash
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init - bash)"
+          pyenv install 3.7.17
+          pyenv global 3.7.17
+          echo "$PYENV_ROOT/bin" >> $GITHUB_PATH
+          echo "$PYENV_ROOT/shims" >> $GITHUB_PATH
+
+      - name: Create Odoo virtual environment
+        run: |
+          addons_path=$(odoo-addons-path --addons-dir "~/code/oca/${{ matrix.odoo_version }}/*")
+          odoo-venv create --verbose ${{ matrix.odoo_version }} \
+            --preset ci \
+            --odoo-dir ~/code/odoo/odoo/${{ matrix.odoo_version }} \
+            --venv-dir ~/code/venvs/${{ matrix.odoo_version }} \
+            --python-version ${{ matrix.python_version }} \
+            --create-launcher \
+            --addons-path=$addons_path


### PR DESCRIPTION
### Before

`setup-uv` with `enable-cache: true` was already added in #17, caching the uv **package cache** (`~/.cache/uv`). However, the `uv` **binary itself** was still downloaded from GitHub Releases on every matrix job run, producing this noise in logs:

```
Trying to find version for uv in: /home/runner/work/odoo-venv/odoo-venv/uv.toml
Could not find file: /home/runner/work/odoo-venv/odoo-venv/uv.toml
Trying to find version for uv in: /home/runner/work/odoo-venv/odoo-venv/pyproject.toml
Could not find file: /home/runner/work/odoo-venv/odoo-venv/pyproject.toml
Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.
Getting latest version from GitHub API...
manifest-file not provided, reading from local file.
manifest-file does not contain version 0.10.8, arch x86_64, platform unknown-linux-gnu. Falling back to GitHub releases.
```

This happens because `setup-uv` runs before checkout — no `pyproject.toml` exists yet, so it can't resolve the version locally and falls back to a GitHub Releases download every time.

### After

An explicit `actions/cache` step now caches `/opt/hostedtoolcache/uv`. `setup-uv` checks this directory first; if the binary is present, it skips the GitHub Releases download and the log noise above disappears on warm runs.

Also incorporates the e2e job split from #18: `test` → `test-native` + new `test-oca` job that runs with OCA modules after `test-native` succeeds.

### Rationale

- `enable-cache: true` — caches the uv **package cache** (pip-equivalent downloads), not the binary
- `ignore-empty-workdir: true` — suppresses the "could not find `uv.toml`/`pyproject.toml`" warnings; the repo isn't checked out yet at this step
- Cache key `uv-binary-${{ runner.os }}-0.10.8` is static (no branch component) so all PRs read the cache warmed by `main`
- Same cache key shared across both `test-native` and `test-oca` — native job warms it, OCA job reuses

---

### Supersedes #18

This PR absorbs all changes and adds uv binary caching to both jobs.

- `pytest` dev dependency not included (out of scope for this PR, added in #27)
