### PR TITLE
feat: translate manifest python dep names to pip package names

### DIFF
--- a/odoo_venv/main.py
+++ b/odoo_venv/main.py
@@ -46,6 +46,7 @@ _MANIFEST_IMPORT_TO_PIP: dict[str, str] = {
     "git": "GitPython",
     "accept_language": "parse-accept-language",
     "dns": "dnspython",
+    "graphql_server": "graphql-server-core",
 }
 
 _COMPARISON_OPS = {


### PR DESCRIPTION
## Summary

In Odoo <= 12.0, `external_dependencies.python` in manifests lists **importable module names** (e.g. `stdnum`, `dateutil`) rather than pip package names, because the module loader used `importlib.import_module` to validate them ([source](https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_module.py#L316-L331)).

Starting from 13.0 modules should use pip package names, but many (especially OCA ports) still use import names in practice, causing both the import name and the pip name to be installed simultaneously.

This PR adds a `_MANIFEST_IMPORT_TO_PIP` mapping and a `_resolve_manifest_dep()` helper that translates known import names to their pip equivalents, applied unconditionally when processing manifest dependencies.

**Mapping includes:** `stdnum`, `dateutil`, `Crypto`, `OpenSSL`, `yaml`, `PIL`, `serial`, `usb`, `magic`, `bs4`, `sklearn`, `ldap`

## Test plan

- [ ] Create a venv for Odoo 12.0 with a module that lists `stdnum` in `external_dependencies.python` — verify `python-stdnum` is installed, not `stdnum`
- [ ] Create a venv for Odoo 16.0+ with an OCA module that still uses `dateutil` — verify `python-dateutil` is installed and `dateutil` does not appear separately