### PR TITLE
fix(presets): bump urllib3 pin from 1.26.5 to 1.26.14 in common preset

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -85,11 +85,13 @@ gevent==21.8.0; sys_platform != 'win32' and python_version == '3.10',
 greenlet==1.1.2; sys_platform != 'win32' and python_version == '3.10',
 vatnumber,
 suds-jurko,
-cbor2==5.4.2 ; python_version < '3.12'
+cbor2==5.4.2 ; python_version < '3.12',
+urllib3==1.26.5; python_version > '3.9' and python_version < '3.12'
 """
 extra_requirement = """
 gevent==22.10.2; sys_platform == 'linux' and python_version == '3.10',
-greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10'
+greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10',
+urllib3==1.26.14; python_version > '3.9' and python_version < '3.12'
 """
 
 # always ignore those exotic requirements unless explicitely added


### PR DESCRIPTION
## Summary

From Odoo 14.0 to 19.0, Odoo's `requirements.txt` pins `urllib3==1.26.5`.

- From 14.0 to 17.0, OCA's sentry module (`server-tools`) needs `sentry-sdk<=1.9.0`, which depends on `urllib3` without any constraint
- Starting from 18.0, it needs `sentry-sdk>=2.0.0,<=2.22.0`, which itself requires `urllib3>=1.26.11`
- `google-books-api-wrapper` requires `urllib3>=1.26.14`

Replaces Odoo's pin with `urllib3==1.26.14` (scoped to Python 3.10/3.11 where the conflict applies), bumping just enough to satisfy all requirements without introducing breaking changes.

## Test plan

- [ ] Create a venv for Odoo 18.0 — verify `urllib3==1.26.14` is installed instead of `1.26.5`
- [ ] Verify `sentry-sdk` and `google-books-api-wrapper` install without conflicts