### PR TITLE
remove(dry-run): drop --dry-run flag as it provides no real validation

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -305,10 +305,6 @@ def create(
         bool,
         typer.Option(help="Display more details to user"),
     ] = False,
-    dry_run: Annotated[
-        bool,
-        typer.Option(),
-    ] = False,
     skip_on_failure: Annotated[
         bool,
         typer.Option(
@@ -409,7 +405,6 @@ def create(
         extra_requirements=extra_requirements_list,
         extra_commands=extra_commands,
         verbose=verbose,
-        dry_run=dry_run,
         skip_on_failure=skip_on_failure,
     )
 

--- a/odoo_venv/main.py
+++ b/odoo_venv/main.py
@@ -168,7 +168,6 @@ def _run_commands_for_stage(
     python_version: str | None,
     venv_dir: Path,
     verbose: bool,
-    dry_run: bool,
 ):
     """Run extra commands for a specific stage.
 
@@ -179,7 +178,6 @@ def _run_commands_for_stage(
         python_version: The Python version
         venv_dir: The virtual environment directory
         verbose: Whether to print verbose output
-        dry_run: Whether to do a dry run
     """
     if not extra_commands:
         return
@@ -210,7 +208,7 @@ def _run_commands_for_stage(
         _print_cmd_info(cmd_spec, stage, verbose)
 
         try:
-            _run_command(command, venv_dir=venv_dir, verbose=verbose, dry_run=dry_run, extra_env=extra_env)
+            _run_command(command, venv_dir=venv_dir, verbose=verbose, extra_env=extra_env)
         except SystemExit:
             _handle_cmd_error(command, stage, when_marker, extra_env)
 
@@ -367,15 +365,12 @@ def _run_command(
     venv_dir: Path | None = None,
     cwd: Path | None = None,
     verbose: bool = False,
-    dry_run: bool = False,
     extra_env: dict[str, str] | None = None,
     raise_on_error: bool = False,
 ):
+
     if verbose:
         typer.secho(f"  → Running: {' '.join(command)}", fg=typer.colors.BLUE)
-
-    if dry_run:
-        return
 
     env = os.environ.copy()
     if venv_dir:
@@ -437,7 +432,6 @@ def _install_requirements_with_retry(
     tmp_path: str,
     venv_dir: Path,
     verbose: bool,
-    dry_run: bool,
     max_retries: int = 10,
 ) -> list[str]:
     """Attempt to install requirements, skipping packages that fail to install.
@@ -458,7 +452,6 @@ def _install_requirements_with_retry(
                 install_args,
                 venv_dir=venv_dir,
                 verbose=False,
-                dry_run=dry_run,
                 raise_on_error=True,
                 extra_env={"UV_PRERELEASE": "allow"},
             )
@@ -672,7 +665,6 @@ def create_odoo_venv(  # noqa: C901
     extra_requirements: list[str] | None = None,
     extra_commands: list[dict] | None = None,
     verbose: bool = False,
-    dry_run: bool = False,
     skip_on_failure: bool = False,
 ):
     odoo_dir = Path(odoo_dir).expanduser().resolve()
@@ -713,16 +705,11 @@ def create_odoo_venv(  # noqa: C901
             _run_command(
                 ["uv", "python", "install", python_version],
                 verbose=verbose,
-                dry_run=dry_run,
             )
     venv_command = ["uv", "venv", str(venv_dir)]
     if python_version:
         venv_command.extend(["--python", python_version])
-    _run_command(
-        venv_command,
-        verbose=verbose,
-        dry_run=dry_run,
-    )
+    _run_command(venv_command, verbose=verbose)
     typer.secho(
         f"  ✔ Virtual environment created at {typer.style(str(venv_dir), fg=typer.colors.YELLOW)}",
     )
@@ -735,10 +722,9 @@ def create_odoo_venv(  # noqa: C901
         python_version,
         venv_dir,
         verbose,
-        dry_run,
     )
 
-    # 3. Install requirements
+    # 3. Process requirements
     all_req_files = []
     if install_odoo_requirements:
         odoo_reqs_file = odoo_dir / "requirements.txt"
@@ -916,7 +902,7 @@ def create_odoo_venv(  # noqa: C901
                     typer.secho(f"      - {req}", fg=typer.colors.CYAN)
 
         if skip_on_failure:
-            skipped = _install_requirements_with_retry(tmp_path, venv_dir=venv_dir, verbose=verbose, dry_run=dry_run)
+            skipped = _install_requirements_with_retry(tmp_path, venv_dir=venv_dir, verbose=verbose)
             if skipped:
                 typer.secho(
                     f"  ⚠  Skipped {len(skipped)} package(s) due to installation failure: "
@@ -924,12 +910,10 @@ def create_odoo_venv(  # noqa: C901
                     fg=typer.colors.YELLOW,
                 )
         else:
-            install_args = ["uv", "pip", "install", "-r", tmp_path]
             _run_command(
-                install_args,
+                ["uv", "pip", "install", "-r", tmp_path],
                 venv_dir=venv_dir,
                 verbose=False,
-                dry_run=dry_run,
                 extra_env={"UV_PRERELEASE": "allow"},
             )
         typer.secho(f"  ✔  {typer.style(req_count, fg=typer.colors.YELLOW)} Packages installed successfully")
@@ -944,7 +928,6 @@ def create_odoo_venv(  # noqa: C901
             ["uv", "pip", "install", "setuptools<58.0", "wheel"],
             venv_dir=venv_dir,
             verbose=verbose,
-            dry_run=dry_run,
         )
         typer.secho("  ✔  setuptools<58.0 wheel installed")
 
@@ -959,13 +942,11 @@ def create_odoo_venv(  # noqa: C901
                     ["uv", "pip", "install", *build_deps],
                     venv_dir=venv_dir,
                     verbose=verbose,
-                    dry_run=dry_run,
                 )
             _run_command(
                 ["uv", "pip", "install", "--no-build-isolation", spec],
                 venv_dir=venv_dir,
                 verbose=verbose,
-                dry_run=dry_run,
             )
             typer.secho(f"  ✔  {typer.style(spec, fg=typer.colors.YELLOW)} installed (no build isolation)")
 
@@ -977,7 +958,6 @@ def create_odoo_venv(  # noqa: C901
         python_version,
         venv_dir,
         verbose,
-        dry_run,
     )
 
     # 4. Install Odoo in editable mode
@@ -987,7 +967,6 @@ def create_odoo_venv(  # noqa: C901
             ["uv", "pip", "install", "-e", f"file://{odoo_dir}#egg=odoo"],
             venv_dir=venv_dir,
             verbose=verbose,
-            dry_run=dry_run,
         )
         typer.secho(
             "  ✔  Installed Odoo in editable mode",
@@ -1001,7 +980,6 @@ def create_odoo_venv(  # noqa: C901
             python_version,
             venv_dir,
             verbose,
-            dry_run,
         )
 
     typer.secho("\n✅ Environment setup complete!", fg=typer.colors.GREEN)

--- a/tests/test_auto_ignore_user_overridden_odoo_reqs.py
+++ b/tests/test_auto_ignore_user_overridden_odoo_reqs.py
@@ -1,5 +1,6 @@
+import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,15 +18,25 @@ def _make_odoo_dir(tmp_path: Path, reqs: str) -> Path:
 
 
 def _run_dry(tmp_path: Path, odoo_dir: Path, **kwargs) -> str:
-    """Run create_odoo_venv in dry-run mode and return the temp requirements file contents.
+    """Run create_odoo_venv with mocked subprocess calls and return the temp requirements file contents.
 
     Patches os.remove to capture the temp file path before deletion.
+    Patches subprocess.run and _run_command to prevent real uv/pip calls
+    (tests only check requirement filtering logic).
     Accepts any create_odoo_venv kwarg to override defaults.
     """
     captured = []
     original_remove = __import__("os").remove
 
-    with patch("odoo_venv.main.os.remove", side_effect=lambda p: captured.append(p)):
+    mock_result = MagicMock(spec=subprocess.CompletedProcess)
+    mock_result.returncode = 0
+    mock_result.stdout = ""
+
+    with (
+        patch("odoo_venv.main.os.remove", side_effect=lambda p: captured.append(p)),
+        patch("odoo_venv.main.subprocess.run", return_value=mock_result),
+        patch("odoo_venv.main._run_command"),
+    ):
         create_odoo_venv(
             odoo_version=kwargs.pop("odoo_version", "17.0"),
             odoo_dir=odoo_dir,
@@ -33,7 +44,6 @@ def _run_dry(tmp_path: Path, odoo_dir: Path, **kwargs) -> str:
             python_version=kwargs.pop("python_version", "3.10"),
             install_odoo=False,
             install_odoo_requirements=True,
-            dry_run=True,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary

- Remove `--dry-run` CLI option entirely — it was silently skipping all subprocess calls, providing zero validation
- Remove `dry_run` parameter from `_run_command`, `_run_commands_for_stage`, `_install_requirements_with_retry`, and `create_odoo_venv`

## Rationale

The `--dry-run` flag was fundamentally broken: it short-circuited all subprocess calls so nothing was actually resolved or validated. Users got a false sense of safety — the command would succeed even with completely invalid configurations. Removing it is cleaner than keeping a misleading feature.

## Test plan

- [ ] `odoo-venv create 17.0` — normal flow works as before
- [ ] `odoo-venv create 17.0 --dry-run` — should now error: unknown option