### PR TITLE
fix(compare): normalize package names per PEP 503

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import json
+import re
 import subprocess
 import sys
 import urllib.request
@@ -443,7 +444,7 @@ def _freeze_venv(venv_dir: Path) -> dict[str, str]:
         line = line.strip()
         if "==" in line:
             name, ver = line.split("==", 1)
-            pkgs[name.lower()] = ver
+            pkgs[re.sub(r"[-_.]+", "-", name).lower()] = ver
     return pkgs
 
 
@@ -473,7 +474,7 @@ def _freeze_remote_venv(host: str, remote_path: str) -> dict[str, str]:
         line = line.strip()
         if "==" in line:
             name, ver = line.split("==", 1)
-            pkgs[name.lower()] = ver
+            pkgs[re.sub(r"[-_.]+", "-", name).lower()] = ver
     return pkgs
 
 
@@ -484,7 +485,7 @@ def _parse_requirements_text(text: str) -> dict[str, str]:
         line = line.strip()
         if line and not line.startswith("#") and "==" in line:
             name, ver = line.split("==", 1)
-            pkgs[name.lower()] = ver
+            pkgs[re.sub(r"[-_.]+", "-", name).lower()] = ver
     return pkgs
 
 


### PR DESCRIPTION
## Summary
- Apply PEP 503 normalization (`[-_.]+` → `-`) when parsing package names from freeze output and requirements files
- Fixes false diffs when comparing uv venvs (which normalize names like `pdfminer-six`) with non-uv venvs (which preserve original names like `pdfminer.six`)

## Test plan
- [ ] Run `odoo-venv compare` with a uv venv and a non-uv venv that both have `pdfminer.six` installed — should show same version, not a diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)