### PR TITLE
feat(create): add --force option to recreate virtual environment

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -345,6 +345,10 @@ def create(
             help="On failure, automatically open a GitHub issue with the full command and output.",
         ),
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Overwrite existing virtual environment."),
+    ] = False,
 ):
     """Create virtual environment to run Odoo"""
     if report_errors:
@@ -406,6 +410,7 @@ def create(
         extra_commands=extra_commands,
         verbose=verbose,
         skip_on_failure=skip_on_failure,
+        force=force,
     )
 
     if create_launcher_flag:

--- a/odoo_venv/main.py
+++ b/odoo_venv/main.py
@@ -666,6 +666,7 @@ def create_odoo_venv(  # noqa: C901
     extra_commands: list[dict] | None = None,
     verbose: bool = False,
     skip_on_failure: bool = False,
+    force: bool = False,
 ):
     odoo_dir = Path(odoo_dir).expanduser().resolve()
     venv_dir = Path(venv_dir).expanduser().resolve()
@@ -709,7 +710,26 @@ def create_odoo_venv(  # noqa: C901
     venv_command = ["uv", "venv", str(venv_dir)]
     if python_version:
         venv_command.extend(["--python", python_version])
-    _run_command(venv_command, verbose=verbose)
+    if force:
+        venv_command.append("--clear")
+    try:
+        _run_command(
+            venv_command,
+            verbose=verbose,
+            raise_on_error=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        if "already exists" in stderr:
+            typer.echo(
+                f"Virtual environment already exists at {typer.style(str(venv_dir), fg=typer.colors.YELLOW)}. "
+                f"Use {typer.style('--force', fg=typer.colors.CYAN)} to recreate it.",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1) from exc
+        typer.echo(stderr, file=sys.stderr)
+        typer.echo(f"Command failed: {' '.join(venv_command)}", file=sys.stderr)
+        raise typer.Exit(1) from exc
     typer.secho(
         f"  ✔ Virtual environment created at {typer.style(str(venv_dir), fg=typer.colors.YELLOW)}",
     )


### PR DESCRIPTION
## Summary

- Adds `--force` flag to the `create` command to allow overwriting existing virtual environments
- Passes the `--force` flag directly to `uv venv` to handle force recreation
- Enables users to quickly update and recreate virtual environments without manual deletion

## Test plan

- [ ] Test creating a new venv with default options
- [ ] Test creating a venv in an existing directory without `--force` (should fail)
- [ ] Test creating a venv with `--force` flag to overwrite existing venv
- [ ] Verify `--force` flag is correctly passed to `uv venv` command
- [ ] Test launcher script creation with `--force` option
- [ ] Verify help text shows the `--force` option with description