### PR TITLE
feat: add show command with requirement origin tracking

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -45,6 +45,84 @@ ODOO_PYTHON_VERSIONS = {
 }
 
 
+_IGNORE_PARAM_NAMES = (
+    "ignore_from_odoo_requirements",
+    "ignore_from_addons_dirs_requirements",
+    "ignore_from_addons_manifests_requirements",
+)
+
+
+def _normalize_pkg_name(pkg: str) -> str:
+    """Normalize a package name to match how create_odoo_venv normalizes ignore names."""
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    try:
+        return Requirement(pkg).name.lower()
+    except InvalidRequirement:
+        return pkg.lower()
+
+
+def _split_ignore_packages(value: str) -> list[str]:
+    """Split a comma-separated ignore string into normalized package names."""
+    return [_normalize_pkg_name(p.strip()) for p in value.split(",") if p.strip()]
+
+
+def _build_ignore_sources(
+    ctx: typer.Context,
+    preset_name: str | None,
+    ignore_args: dict[str, str | None],
+) -> dict[str, str]:
+    """Build a mapping of {package_name: source_tag} for explicit ignores.
+
+    Determines whether each ignored package came from a preset or a CLI argument
+    by inspecting ``ctx.get_parameter_source()``.  The CLI flag name is always
+    included so the user knows *which* argument caused the ignore.
+    """
+    import click
+
+    sources: dict[str, str] = {}
+    for param_name, value in ignore_args.items():
+        if not value:
+            continue
+        cli_flag = f"--{param_name.replace('_', '-')}"
+        is_from_preset = ctx.get_parameter_source(param_name) == click.core.ParameterSource.DEFAULT_MAP
+        for normalized in _split_ignore_packages(value):
+            if is_from_preset and preset_name:
+                sources[normalized] = f"explicit_ignore:preset:{preset_name}:{cli_flag}"
+            else:
+                sources[normalized] = f"explicit_ignore:{cli_flag}"
+    return sources
+
+
+def _build_ignore_sources_from_config(config: dict[str, str | bool]) -> dict[str, str]:
+    """Build ignore_sources from a stored .odoo-venv.toml config dict.
+
+    Used by the ``update`` command where there's no Typer context to inspect.
+    Loads the preset (if any) to determine which ignores came from it vs CLI.
+    """
+    preset_name = config.get("preset") or None
+    preset_ignores: dict[str, set[str]] = {}  # param_name → {normalized_pkg, ...}
+
+    if preset_name:
+        all_presets = load_presets()
+        if preset_name in all_presets:
+            preset_data = asdict(all_presets[preset_name])
+            for param_name in _IGNORE_PARAM_NAMES:
+                val = preset_data.get(param_name, "") or ""
+                preset_ignores[param_name] = set(_split_ignore_packages(val))
+
+    sources: dict[str, str] = {}
+    for param_name in _IGNORE_PARAM_NAMES:
+        value = str(config.get(param_name, "") or "")
+        cli_flag = f"--{param_name.replace('_', '-')}"
+        for normalized in _split_ignore_packages(value):
+            if normalized in preset_ignores.get(param_name, set()):
+                sources[normalized] = f"explicit_ignore:preset:{preset_name}:{cli_flag}"
+            else:
+                sources[normalized] = f"explicit_ignore:{cli_flag}"
+    return sources
+
+
 def _apply_preset(ctx: typer.Context, preset_name: str, all_presets: dict, *, silent: bool = False):
     """Apply a preset's options to the Typer context.
 
@@ -118,7 +196,7 @@ def from_config_callback(ctx: typer.Context, param: typer.CallbackParam, value: 
 
     path = Path(value).expanduser().resolve()
     try:
-        args, _meta = read_venv_config(path)
+        args, _meta, _reqs, _ignored = read_venv_config(path)
     except FileNotFoundError:
         typer.secho(f"error: config file not found at {path}", fg=typer.colors.RED)
         raise typer.Exit(1) from None
@@ -456,7 +534,18 @@ def create(
     # Get extra_commands from preset if available
     extra_commands = ctx.obj.get("extra_commands") if ctx.obj else None
 
-    create_odoo_venv(
+    # Build ignore_sources: map each ignored package to its source tag
+    ignore_sources = _build_ignore_sources(
+        ctx,
+        preset,
+        {
+            "ignore_from_odoo_requirements": ignore_from_odoo_requirements,
+            "ignore_from_addons_dirs_requirements": ignore_from_addons_dirs_requirements,
+            "ignore_from_addons_manifests_requirements": ignore_from_addons_manifests_requirements,
+        },
+    )
+
+    result = create_odoo_venv(
         odoo_version=odoo_version,
         odoo_dir=str(odoo_dir_path),
         venv_dir=str(venv_dir_path),
@@ -475,6 +564,7 @@ def create(
         verbose=verbose,
         skip_on_failure=skip_on_failure,
         force=force,
+        ignore_sources=ignore_sources,
     )
 
     if create_launcher_flag:
@@ -506,7 +596,13 @@ def create(
         "project_dir": project_dir_value or "",
     }
 
-    write_venv_config(venv_dir_path, config_args, odoo_version)
+    write_venv_config(
+        venv_dir_path,
+        config_args,
+        odoo_version,
+        requirements=result.requirements or None,
+        ignored=result.ignored or None,
+    )
 
 
 def _is_uv_venv(venv_dir: Path) -> bool:
@@ -830,8 +926,8 @@ def create_odoo_launcher(
     create_launcher(odoo_version, venv_dir_path, odoo_dir=odoo_dir_path, force=force)
 
 
-def _build_update_venv(merged: dict, odoo_version: str, tmp_venv_path: Path) -> None:
-    """Create a temporary venv from merged config."""
+def _build_update_venv(merged: dict, odoo_version: str, tmp_venv_path: Path):
+    """Create a temporary venv from merged config. Returns VenvResult."""
     # Resolve preset's extra_commands if a preset is set
     extra_commands = None
     merged_preset = merged.get("preset")
@@ -852,7 +948,10 @@ def _build_update_venv(merged: dict, odoo_version: str, tmp_venv_path: Path) -> 
     extra_req_str = merged.get("extra_requirement", "")
     extra_requirements_list = split_escaped(extra_req_str) if extra_req_str else []
 
-    create_odoo_venv(
+    # Build ignore_sources from stored config — check which ignores come from the preset
+    ignore_sources = _build_ignore_sources_from_config(merged)
+
+    return create_odoo_venv(
         odoo_version=odoo_version,
         odoo_dir=merged.get("odoo_dir", ""),
         venv_dir=str(tmp_venv_path),
@@ -870,6 +969,7 @@ def _build_update_venv(merged: dict, odoo_version: str, tmp_venv_path: Path) -> 
         extra_commands=extra_commands,
         verbose=False,
         skip_on_failure=merged.get("skip_on_failure", False),
+        ignore_sources=ignore_sources,
     )
 
 
@@ -915,7 +1015,7 @@ def update(
         )
         raise typer.Exit(1)
 
-    toml_args, meta = read_venv_config(venv_path)
+    toml_args, meta, _reqs, _ignored = read_venv_config(venv_path)
     odoo_version_val = meta.get("odoo_version", "")
 
     # Create tmp venv
@@ -927,10 +1027,16 @@ def update(
 
     swapped = False
     try:
-        _build_update_venv(toml_args, odoo_version_val, tmp_venv_path)
+        result = _build_update_venv(toml_args, odoo_version_val, tmp_venv_path)
 
-        # Copy original config into the new venv (config is unchanged during update)
-        shutil.copy2(config_file, tmp_venv_path / VENV_CONFIG_FILENAME)
+        # Write fresh config with updated origin tracking data
+        write_venv_config(
+            tmp_venv_path,
+            toml_args,
+            odoo_version_val,
+            requirements=result.requirements or None,
+            ignored=result.ignored or None,
+        )
 
         typer.secho("\nComparing packages...", fg=typer.colors.CYAN)
         old_pkgs = _freeze_venv(venv_path)
@@ -964,3 +1070,238 @@ def update(
         # Clean up tmp venv
         if not swapped and tmp_venv_path.exists():
             shutil.rmtree(tmp_venv_path)
+
+
+def _origin_label(origin: str) -> str:
+    """Return a short human-readable label for a requirement origin tag."""
+    if origin == "odoo":
+        return "Odoo requirements.txt"
+    if origin == "extra_requirement":
+        return "Extra requirement"
+    if origin == "transitive":
+        return "Transitive"
+    if origin == "build_tool":
+        return "Build tool"
+    if origin == "no_build_isolation":
+        return "No-build-isolation"
+    if origin.startswith("addons_dir:"):
+        return f"Addons dir: {origin[len('addons_dir:') :]}"
+    if origin.startswith("manifest:"):
+        return f"Addon manifest: {origin[len('manifest:') :]}"
+    if origin.startswith("extra_requirements_file:"):
+        return f"Extra file: {origin[len('extra_requirements_file:') :]}"
+    return origin
+
+
+def _ignored_reason_label(reason: str) -> str:
+    """Return a short human-readable label for an ignored reason tag."""
+    if reason == "explicit_ignore":
+        return "Explicitly ignored"
+    if reason.startswith("explicit_ignore:preset:"):
+        # Format: explicit_ignore:preset:<name>:<flag>
+        parts = reason.split(":", 3)  # ["explicit_ignore", "preset", "<name>", "<flag>"]
+        preset_name = parts[2] if len(parts) > 2 else "?"
+        cli_flag = parts[3] if len(parts) > 3 else ""
+        return f'Preset "{preset_name}" ({cli_flag})' if cli_flag else f'Preset "{preset_name}"'
+    if reason.startswith("explicit_ignore:"):
+        # Format: explicit_ignore:<flag>
+        cli_flag = reason[len("explicit_ignore:") :]
+        return cli_flag
+    if reason == "auto_override":
+        return "Overridden by user constraint"
+    if reason.startswith("auto_override:"):
+        source = reason[len("auto_override:") :]
+        return f"Overridden by {source}"
+    if reason == "install_failure":
+        return "Install failure (skip-on-failure)"
+    if reason.startswith("transitive_conflict:"):
+        return f"Transitive conflict with {reason[len('transitive_conflict:') :]}"
+    return reason
+
+
+_ORIGIN_ORDER = [
+    "odoo",
+    "addons_dir:",
+    "manifest:",
+    "extra_requirement",
+    "extra_requirements_file:",
+    "no_build_isolation",
+    "build_tool",
+    "transitive",
+]
+
+
+def _origin_sort_key(origin: str) -> int:
+    for i, prefix in enumerate(_ORIGIN_ORDER):
+        if origin == prefix or origin.startswith(prefix):
+            return i
+    return len(_ORIGIN_ORDER)
+
+
+def _group_requirements(
+    requirements: dict[str, list[str]], no_transitive: bool
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Group packages by origin and collect transitive children for tree rendering.
+
+    Returns ``(groups, transitive_children)`` where *groups* maps origin keys to
+    package lists and *transitive_children* maps parent packages to their transitive deps.
+    """
+    transitive_children: dict[str, list[str]] = {}
+    transitive_with_parent: set[str] = set()
+
+    groups: dict[str, list[str]] = {}
+    for pkg, origins in requirements.items():
+        is_transitive = all(o.startswith("transitive") for o in origins)
+        if no_transitive and is_transitive:
+            continue
+        if is_transitive:
+            parents = [o[len("transitive:") :] for o in origins if o.startswith("transitive:")]
+            if parents:
+                transitive_with_parent.add(pkg)
+                for parent in parents:
+                    transitive_children.setdefault(parent, []).append(pkg)
+                continue
+        primary = min(origins, key=_origin_sort_key)
+        groups.setdefault(primary, []).append(pkg)
+
+    # Orphaned transitive deps (parent not rendered anywhere) → flat "Transitive" group
+    rendered_pkgs = {pkg for pkgs in groups.values() for pkg in pkgs}
+    rendered_pkgs |= {child for children in transitive_children.values() for child in children}
+    for pkg in sorted(transitive_with_parent):
+        parents = [o[len("transitive:") :] for o in requirements[pkg] if o.startswith("transitive:")]
+        if not any(p in rendered_pkgs for p in parents):
+            groups.setdefault("transitive", []).append(pkg)
+
+    return groups, transitive_children
+
+
+def _build_pkg_lines(pkg: str, transitive_children: dict[str, list[str]], indent: str = "") -> list[str]:
+    """Build display lines for a package and its transitive children (recursive)."""
+    lines = [f"[cyan]{pkg}[/cyan]" if not indent else f"[dim]{indent}{pkg}[/dim]"]
+    children = sorted(transitive_children.get(pkg, []))
+    for i, child in enumerate(children):
+        is_last = i == len(children) - 1
+        prefix = "└── " if is_last else "├── "
+        continuation = "    " if is_last else "│   "
+        lines.append(f"[dim]{indent}{prefix}{child}[/dim]")
+        # Add grandchildren with proper indentation
+        grandchildren = sorted(transitive_children.get(child, []))
+        for j, grandchild in enumerate(grandchildren):
+            gc_prefix = "└── " if j == len(grandchildren) - 1 else "├── "
+            lines.append(f"[dim]{indent}{continuation}{gc_prefix}{grandchild}[/dim]")
+    return lines
+
+
+def _render_blocks_as_table(blocks: list[list[str]]):
+    """Render a list of markup-line blocks into a single Rich Table."""
+    from rich import box
+    from rich.table import Table
+    from rich.text import Text
+
+    t = Table(box=box.SIMPLE, show_header=False, padding=(0, 1))
+    t.add_column("Package", no_wrap=True)
+    for block in blocks:
+        for line in block:
+            t.add_row(Text.from_markup(line))
+    return t
+
+
+def _render_multicolumn(blocks: list[list[str]]):
+    """Distribute blocks across balanced columns and return a Rich Columns renderable."""
+    import math
+
+    from rich.columns import Columns
+
+    total_lines = sum(len(b) for b in blocks)
+    num_cols = min(3, math.ceil(total_lines / 20))
+    target_lines = math.ceil(total_lines / num_cols)
+    columns_blocks: list[list[list[str]]] = [[]]
+    current_lines = 0
+    for block in blocks:
+        if current_lines > 0 and current_lines + len(block) > target_lines and len(columns_blocks) < num_cols:
+            columns_blocks.append([])
+            current_lines = 0
+        columns_blocks[-1].append(block)
+        current_lines += len(block)
+    return Columns([_render_blocks_as_table(cb) for cb in columns_blocks], padding=(0, 2))
+
+
+def _print_requirements_panels(console, requirements: dict[str, list[str]], no_transitive: bool) -> None:
+    from rich.panel import Panel
+
+    if not requirements:
+        console.print("\n[dim]No requirement origin data available. Re-create the venv to populate it.[/dim]")
+        return
+
+    groups, transitive_children = _group_requirements(requirements, no_transitive)
+
+    console.print()
+    for origin in sorted(groups.keys(), key=_origin_sort_key):
+        pkgs = sorted(groups[origin])
+        label = _origin_label(origin)
+
+        blocks: list[list[str]] = [_build_pkg_lines(pkg, transitive_children) for pkg in pkgs]
+        total_lines = sum(len(b) for b in blocks)
+        content = (
+            _render_multicolumn(blocks) if len(pkgs) > 10 and total_lines > 15 else _render_blocks_as_table(blocks)
+        )
+        console.print(Panel(content, title=f"[bold green]{label}[/bold green] ({len(pkgs)})", expand=False))
+
+
+def _print_ignored_panel(console, ignored: dict[str, list[str]]) -> None:
+    from rich import box
+    from rich.panel import Panel
+    from rich.table import Table
+    from rich.text import Text
+
+    table = Table(box=box.ROUNDED, show_header=True, header_style="bold yellow")
+    table.add_column("Package", style="bold", no_wrap=True)
+    table.add_column("Reason")
+    for pkg in sorted(ignored.keys()):
+        reasons = ", ".join(_ignored_reason_label(r) for r in ignored[pkg])
+        table.add_row(pkg, Text(reasons, style="yellow"))
+    console.print(Panel(table, title="[bold yellow]Ignored Packages[/bold yellow]", expand=False))
+
+
+@app.command()
+def show(
+    venv_dir: Annotated[str, typer.Argument(help="Path to the venv directory.")] = "./.venv",
+    no_transitive: Annotated[
+        bool,
+        typer.Option("--no-transitive", help="Hide transitive dependencies."),
+    ] = False,
+):
+    """Show the configuration and installed packages of a venv."""
+    from rich.console import Console
+    from rich.panel import Panel
+
+    console = Console()
+    venv_path = Path(venv_dir).expanduser().resolve()
+
+    try:
+        args, meta, requirements, ignored = read_venv_config(venv_path)
+    except FileNotFoundError:
+        typer.secho(
+            f"error: no .odoo-venv.toml found in {venv_path}\nCreate a venv first with: odoo-venv create ...",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1) from None
+
+    # --- Config panel ---
+    odoo_version = meta.get("odoo_version", "unknown")
+    tool_version = meta.get("tool_version", "unknown")
+    config_lines = [
+        f"[bold]Venv:[/bold]          {venv_path}",
+        f"[bold]Odoo version:[/bold]  {odoo_version}",
+        f"[bold]Tool version:[/bold]  {tool_version}",
+    ]
+    for key, label in [("preset", "Preset"), ("python_version", "Python"), ("odoo_dir", "Odoo dir")]:
+        if val := args.get(key):
+            config_lines.append(f"[bold]{label + ':':<14}[/bold] {val}")
+    console.print(Panel("\n".join(config_lines), title="[bold cyan]Venv Configuration[/bold cyan]", expand=False))
+
+    _print_requirements_panels(console, requirements, no_transitive)
+
+    if ignored:
+        console.print()
+        _print_ignored_panel(console, ignored)

--- a/odoo_venv/main.py
+++ b/odoo_venv/main.py
@@ -7,12 +7,22 @@ import sys
 import tempfile
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
 from packaging.markers import Marker, default_environment
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import parse as parse_version
+
+
+@dataclass
+class VenvResult:
+    """Result of create_odoo_venv() containing origin tracking data."""
+
+    requirements: dict[str, list[str]] = field(default_factory=dict)
+    ignored: dict[str, list[str]] = field(default_factory=dict)
+
 
 PKG_NAME_PATTERN = re.compile(r"(?P<lib_name>[a-z0-9A-Z\-\_\.]+)((>|<|=)=)?(.*)")
 
@@ -304,6 +314,46 @@ _KNOWN_TRANSITIVE_CONFLICTS: dict[str, list[str]] = {
     # requests==2.20.0 pin.  No compatible klaviyo-api version exists without relaxing it.
     "klaviyo-api": ["requests"],
 }
+
+
+def _build_labeled_user_sources(
+    extra_requirements: list[str] | None,
+    extra_requirements_file: str | None,
+    install_addons_dirs_requirements: bool,
+    addons_paths: list[str] | None,
+    manifest_files: list[Path],
+    parsed_manifests: dict[Path, dict],
+) -> list[tuple[list[str], str]]:
+    """Build (req_lines, label) pairs for each user requirement source."""
+    result: list[tuple[list[str], str]] = []
+    if extra_requirements:
+        result.append((extra_requirements, "--extra-requirement"))
+    if extra_requirements_file:
+        path = Path(extra_requirements_file).expanduser().resolve()
+        if path.exists():
+            result.append((path.read_text(encoding="utf-8").splitlines(), f"--extra-requirements-file ({path.name})"))
+    if install_addons_dirs_requirements and addons_paths:
+        for p in addons_paths:
+            req_file = Path(p) / "requirements.txt"
+            if req_file.exists():
+                result.append((req_file.read_text(encoding="utf-8").splitlines(), f"addons dir ({Path(p).name})"))
+    for mf in manifest_files:
+        ext_deps = parsed_manifests[mf].get("external_dependencies", {})
+        if isinstance(ext_deps.get("python"), list):
+            result.append((ext_deps["python"], f"addon manifest ({mf.parent.name})"))
+    return result
+
+
+def _identify_constrained_sources(
+    labeled_sources: list[tuple[list[str], str]],
+    target_env: dict[str, str],
+) -> dict[str, str]:
+    """Map each constrained package to its user source label (e.g. "--extra-requirement")."""
+    sources: dict[str, str] = {}
+    for lines, label in labeled_sources:
+        for pkg in _collect_constrained_packages(lines, target_env):
+            sources.setdefault(pkg, label)
+    return sources
 
 
 def _scan_user_sources(
@@ -611,20 +661,20 @@ def _process_requirement_line(
     ignored_req_map: dict,
     tmp_file,
     target_env_for_markers: dict[str, str],
-) -> bool:
+) -> tuple[bool, str | None]:
     req_line = req_line.strip()
     if not req_line or req_line.startswith("#"):
-        return False
+        return False, None
 
     try:
         valid_line = _keep_if_marker_matches(req_line, env=target_env_for_markers)
         if not valid_line:
-            return False
+            return False, None
 
         req = Requirement(valid_line)
 
         should_ignore = False
-        req_name_normalized = re.sub(r"[-_.]", "-", req.name.lower())
+        req_name_normalized = re.sub(r"[-_.]+", "-", req.name.lower())
         if req_name_normalized in ignored_req_map:
             for ignored_req in ignored_req_map[req_name_normalized]:
                 if not ignored_req.specifier or (
@@ -634,18 +684,60 @@ def _process_requirement_line(
                     break
 
         if should_ignore:
-            return False
+            return False, None
         else:
             tmp_file.write(valid_line + "\n")
-            return True
+            return True, req_name_normalized
 
     except InvalidRequirement:
         match = PKG_NAME_PATTERN.match(req_line)
         if match and match.group("lib_name").lower().strip() in ignored_req_map:
-            return False
+            return False, None
         else:
             tmp_file.write(req_line + "\n")
-            return True
+            pkg_name = re.sub(r"[-_.]+", "-", match.group("lib_name").lower()) if match else None
+            return True, pkg_name
+
+
+def _freeze_venv(venv_dir: Path) -> dict[str, str]:
+    """Run ``uv pip freeze`` on a venv and return ``{normalized_name: version}``."""
+    cmd = ["uv", "pip", "freeze", "--python", str(venv_dir)]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603
+    pkgs: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if "==" in line:
+            name, ver = line.split("==", 1)
+            pkgs[re.sub(r"[-_.]+", "-", name).lower()] = ver
+    return pkgs
+
+
+def _build_reverse_dep_map(venv_dir: Path, explicit_pkgs: set[str]) -> dict[str, list[str]]:
+    """Build a map of {transitive_dep: [parent_pkg, ...]} using ``uv pip show``.
+
+    Runs ``uv pip show`` on all *explicit_pkgs* at once, parses ``Requires:`` lines,
+    and returns a reverse mapping so each dependency knows which explicit package pulled it in.
+    """
+    if not explicit_pkgs:
+        return {}
+    cmd = ["uv", "pip", "show", "--python", str(venv_dir), *sorted(explicit_pkgs)]
+    result = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+    if result.returncode != 0:
+        return {}
+
+    reverse: dict[str, list[str]] = {}
+    current_name = ""
+    for line in result.stdout.splitlines():
+        if line.startswith("Name:"):
+            current_name = re.sub(r"[-_.]+", "-", line.split(":", 1)[1].strip()).lower()
+        elif line.startswith("Requires:") and current_name:
+            deps_str = line.split(":", 1)[1].strip()
+            if deps_str:
+                for dep in deps_str.split(","):
+                    dep_normalized = re.sub(r"[-_.]+", "-", dep.strip()).lower()
+                    if dep_normalized:
+                        reverse.setdefault(dep_normalized, []).append(current_name)
+    return reverse
 
 
 def create_odoo_venv(  # noqa: C901
@@ -667,9 +759,15 @@ def create_odoo_venv(  # noqa: C901
     verbose: bool = False,
     skip_on_failure: bool = False,
     force: bool = False,
-):
+    ignore_sources: dict[str, str] | None = None,
+) -> VenvResult:
     odoo_dir = Path(odoo_dir).expanduser().resolve()
     venv_dir = Path(venv_dir).expanduser().resolve()
+    odoo_reqs_path = odoo_dir / "requirements.txt"
+
+    # Origin tracking dicts
+    origins: dict[str, list[str]] = defaultdict(list)
+    ignored_tracking: dict[str, list[str]] = defaultdict(list)
 
     # 1. Determine Python version
     if not python_version:
@@ -781,6 +879,9 @@ def create_odoo_venv(  # noqa: C901
                 fg=typer.colors.RED,
             )
 
+    # Snapshot explicit ignores now — ignored_req_map gets more entries later (auto-override, NBI)
+    explicit_ignore_names: set[str] = set(ignored_req_map.keys())
+
     # Hoist manifest discovery so it can be reused in both the pre-scan and the main loop.
     manifest_files: list[Path] = []
     if install_addons_manifests_requirements and addons_paths:
@@ -792,11 +893,23 @@ def create_odoo_venv(  # noqa: C901
     # Collect the set of packages actually present in the base requirement files
     # (Odoo's requirements.txt and addons dirs).  Auto-ignore logic is restricted to
     # this set so we never silently drop a package that Odoo doesn't pin.
+    # Also build a specifier map for display purposes (e.g. "lxml==4.9.0").
     base_pinned: set[str] = set()
+    base_specifiers: dict[str, str] = {}  # {normalized_name: "name==version"}
     for req_file in all_req_files:
-        base_pinned |= _collect_mentioned_packages(
-            req_file.read_text(encoding="utf-8").splitlines(), target_env_for_markers
-        )
+        lines = req_file.read_text(encoding="utf-8").splitlines()
+        base_pinned |= _collect_mentioned_packages(lines, target_env_for_markers)
+        for line in lines:
+            line = line.split("#")[0].strip()
+            if not line:
+                continue
+            try:
+                req = Requirement(line)
+                if req.specifier and (not req.marker or req.marker.evaluate(environment=target_env_for_markers)):
+                    name = re.sub(r"[-_.]+", "-", req.name.lower())
+                    base_specifiers[name] = f"{req.name}{req.specifier}"
+            except InvalidRequirement:
+                pass
 
     scan_args = (
         extra_requirements,
@@ -811,13 +924,28 @@ def create_odoo_venv(  # noqa: C901
     # Pre-scan user sources for packages with version specifiers.
     # When a user source pins/constrains a package that Odoo also pins, Odoo's stricter
     # pin is skipped automatically so the user's version wins without an explicit ignore entry.
+    # Track which user source provided each override for display purposes.
     user_constrained = _scan_user_sources(_collect_constrained_packages, *scan_args)
+    labeled_sources = _build_labeled_user_sources(
+        extra_requirements,
+        extra_requirements_file,
+        install_addons_dirs_requirements,
+        addons_paths,
+        manifest_files,
+        parsed_manifests,
+    )
+    user_constrained_sources = _identify_constrained_sources(labeled_sources, target_env_for_markers)
     for pkg_name in user_constrained & base_pinned:
         if not any(not r.specifier for r in ignored_req_map[pkg_name]):
             ignored_req_map[pkg_name].append(Requirement(pkg_name))
+            # Skip auto_override tracking when already explicitly ignored (e.g. by preset)
+            if pkg_name not in explicit_ignore_names:
+                source = user_constrained_sources.get(pkg_name, "user requirement")
+                ignored_tracking[pkg_name].append(f"auto_override:{source}")
             if verbose:
+                source = user_constrained_sources.get(pkg_name, "user requirement")
                 typer.secho(
-                    f"  i  Auto-ignoring Odoo's '{pkg_name}' pin (overridden by user requirement)",
+                    f"  i  Auto-ignoring Odoo's '{pkg_name}' pin (overridden by {source})",
                     fg=typer.colors.CYAN,
                 )
 
@@ -831,6 +959,9 @@ def create_odoo_venv(  # noqa: C901
                 continue
             if not any(not r.specifier for r in ignored_req_map[transitive]):
                 ignored_req_map[transitive].append(Requirement(transitive))
+                # Skip transitive_conflict tracking when already explicitly ignored
+                if transitive not in explicit_ignore_names:
+                    ignored_tracking[transitive].append(f"transitive_conflict:{pkg_name}")
                 if verbose:
                     typer.secho(
                         f"  i  Auto-ignoring Odoo's '{transitive}' pin (transitively required by '{pkg_name}')",
@@ -859,11 +990,18 @@ def create_odoo_venv(  # noqa: C901
             no_build_isolation_specs.update(_collect_no_build_isolation_specs(ext_deps["python"], *_nbi_args))
     for pkg_name in no_build_isolation_specs:
         ignored_req_map[pkg_name].append(Requirement(pkg_name))
+        origins[pkg_name].append("no_build_isolation")
         if verbose:
             typer.secho(
                 f"  i  Auto-ignoring '{pkg_name}' (will install separately with --no-build-isolation)",
                 fg=typer.colors.CYAN,
             )
+
+    # Record explicit ignores with source info when available
+    _ignore_sources = ignore_sources or {}
+    for pkg_name in explicit_ignore_names:
+        source_tag = _ignore_sources.get(pkg_name, "explicit_ignore")
+        ignored_tracking[pkg_name].append(source_tag)
 
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt", encoding="utf-8") as tmp:
         tmp_path = tmp.name
@@ -871,37 +1009,55 @@ def create_odoo_venv(  # noqa: C901
 
         if all_req_files:
             for req_file in all_req_files:
+                origin = "odoo" if req_file == odoo_reqs_path else f"addons_dir:{req_file.parent}"
                 with open(req_file, encoding="utf-8") as f:
                     for line in f:
-                        if _process_requirement_line(line, ignored_req_map, tmp, target_env_for_markers):
+                        written, pkg_name = _process_requirement_line(
+                            line, ignored_req_map, tmp, target_env_for_markers
+                        )
+                        if written and pkg_name:
                             req_count += 1
+                            if origin not in origins[pkg_name]:
+                                origins[pkg_name].append(origin)
 
         if extra_requirements:
             for req_line in extra_requirements:
-                if _process_requirement_line(req_line, {}, tmp, target_env_for_markers):
+                written, pkg_name = _process_requirement_line(req_line, {}, tmp, target_env_for_markers)
+                if written and pkg_name:
                     req_count += 1
+                    if "extra_requirement" not in origins[pkg_name]:
+                        origins[pkg_name].append("extra_requirement")
 
         if extra_requirements_file:
             extra_req_file = Path(extra_requirements_file).expanduser().resolve()
             if extra_req_file.exists():
+                origin = f"extra_requirements_file:{extra_req_file}"
                 with open(extra_req_file, encoding="utf-8") as f:
                     for line in f:
-                        if _process_requirement_line(line, {}, tmp, target_env_for_markers):
+                        written, pkg_name = _process_requirement_line(line, {}, tmp, target_env_for_markers)
+                        if written and pkg_name:
                             req_count += 1
+                            if origin not in origins[pkg_name]:
+                                origins[pkg_name].append(origin)
 
         if manifest_files:
             for manifest_file in manifest_files:
+                module_name = manifest_file.parent.name
                 manifest = parsed_manifests[manifest_file]
                 ext_deps = manifest.get("external_dependencies", {})
                 if isinstance(ext_deps.get("python"), list):
                     for dep in ext_deps["python"]:
-                        if _process_requirement_line(
+                        written, pkg_name = _process_requirement_line(
                             _resolve_manifest_dep(dep),
                             ignored_req_map,
                             tmp,
                             target_env_for_markers,
-                        ):
+                        )
+                        if written and pkg_name:
                             req_count += 1
+                            origin = f"manifest:{module_name}"
+                            if origin not in origins[pkg_name]:
+                                origins[pkg_name].append(origin)
 
     skipped: list[str] = []
     if req_count > 0:
@@ -929,6 +1085,10 @@ def create_odoo_venv(  # noqa: C901
                     + ", ".join(typer.style(p, fg=typer.colors.YELLOW) for p in skipped),
                     fg=typer.colors.YELLOW,
                 )
+                for pkg in skipped:
+                    pkg_normalized = re.sub(r"[-_.]+", "-", pkg.lower())
+                    ignored_tracking[pkg_normalized].append("install_failure")
+                    origins.pop(pkg_normalized, None)
         else:
             _run_command(
                 ["uv", "pip", "install", "-r", tmp_path],
@@ -950,6 +1110,9 @@ def create_odoo_venv(  # noqa: C901
             verbose=verbose,
         )
         typer.secho("  ✔  setuptools<58.0 wheel installed")
+        for build_tool in ("setuptools", "wheel"):
+            if "build_tool" not in origins[build_tool]:
+                origins[build_tool].append("build_tool")
 
     # Install packages that cannot be built in isolation (e.g. vatnumber, rfc6266-parser).
     if no_build_isolation_specs:
@@ -1007,5 +1170,37 @@ def create_odoo_venv(  # noqa: C901
         f"Activate it with: source {typer.style(str(venv_dir / 'bin' / 'activate'), fg=typer.colors.YELLOW)}",
     )
 
-    if skipped:
-        sys.exit(1)
+    # Identify transitive dependencies: packages installed but not explicitly requested.
+    # Build a reverse dep map to record which explicit package pulled each transitive dep in.
+    try:
+        frozen = _freeze_venv(venv_dir)
+        transitive_pkgs = {p for p in frozen if p not in origins and p not in ignored_tracking}
+        if transitive_pkgs:
+            # Scan ALL installed packages so multi-level transitive deps are resolved
+            reverse_deps = _build_reverse_dep_map(venv_dir, set(frozen.keys()))
+            for pkg_name in transitive_pkgs:
+                parents = reverse_deps.get(pkg_name, [])
+                if parents:
+                    for parent in parents:
+                        origins[pkg_name].append(f"transitive:{parent}")
+                else:
+                    origins[pkg_name].append("transitive")
+    except Exception:  # noqa: S110
+        pass
+
+    if install_odoo:
+        origins["odoo"].append("odoo")
+
+    # Enrich ignored keys with version specifiers for display (e.g. "lxml==4.9.0")
+    ignored_with_specifiers: dict[str, list[str]] = {}
+    for pkg_name, reasons in ignored_tracking.items():
+        display_key = base_specifiers.get(pkg_name, pkg_name)
+        ignored_with_specifiers[display_key] = reasons
+
+    exit_code = 1 if skipped else 0
+    result = VenvResult(requirements=dict(origins), ignored=ignored_with_specifiers)
+
+    if exit_code != 0:
+        sys.exit(exit_code)
+
+    return result

--- a/odoo_venv/utils.py
+++ b/odoo_venv/utils.py
@@ -137,7 +137,7 @@ def load_presets() -> dict[str, Preset]:
     return {name: Preset.from_dict(options) for name, options in presets_data.items()}
 
 
-def _format_toml_value(value: str | bool) -> str:
+def _format_toml_value(value: str | bool | list[str]) -> str:
     """Format a Python value as a TOML literal.
 
     >>> _format_toml_value(True)
@@ -146,6 +146,10 @@ def _format_toml_value(value: str | bool) -> str:
     'false'
     >>> _format_toml_value("hello")
     '"hello"'
+    >>> _format_toml_value(["odoo", "manifest:sale"])
+    '["odoo", "manifest:sale"]'
+    >>> _format_toml_value([])
+    '[]'
     >>> _format_toml_value('path\\\\with"quotes')
     '"path\\\\\\\\with\\\\"quotes"'
     >>> _format_toml_value("line1\\nline2")
@@ -153,6 +157,9 @@ def _format_toml_value(value: str | bool) -> str:
     """
     if isinstance(value, bool):
         return "true" if value else "false"
+    if isinstance(value, list):
+        items = ", ".join(_format_toml_value(item) for item in value)
+        return f"[{items}]"
     # Escape backslashes first, then characters illegal in TOML basic strings
     escaped = (
         value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
@@ -164,6 +171,9 @@ def write_venv_config(
     venv_dir: Path,
     args: dict[str, str | bool],
     odoo_version: str,
+    *,
+    requirements: dict[str, list[str]] | None = None,
+    ignored: dict[str, list[str]] | None = None,
 ) -> Path:
     """Write .odoo-venv.toml to *venv_dir* with the given args and metadata.
 
@@ -179,15 +189,31 @@ def write_venv_config(
         if key in args:
             lines.append(f"{key} = {_format_toml_value(args[key])}")
 
+    if requirements:
+        lines.append("")
+        lines.append("[requirements]")
+        for pkg_name in sorted(requirements):
+            lines.append(f"{pkg_name} = {_format_toml_value(requirements[pkg_name])}")
+
+    if ignored:
+        lines.append("")
+        lines.append("[ignored]")
+        for pkg_name in sorted(ignored):
+            # Quote keys that contain TOML-special characters (e.g. "lxml==4.9.0")
+            key = f'"{pkg_name}"' if any(c in pkg_name for c in '=.,"[]') else pkg_name
+            lines.append(f"{key} = {_format_toml_value(ignored[pkg_name])}")
+
     config_path = venv_dir / VENV_CONFIG_FILENAME
     config_path.write_text("\n".join(lines) + "\n")
     return config_path
 
 
-def read_venv_config(path: Path) -> tuple[dict[str, str | bool], dict[str, str]]:
+def read_venv_config(
+    path: Path,
+) -> tuple[dict[str, str | bool], dict[str, str], dict[str, list[str]], dict[str, list[str]]]:
     """Read .odoo-venv.toml from *path* (directory or file).
 
-    Returns ``(args_dict, metadata_dict)``.
+    Returns ``(args_dict, metadata_dict, requirements_dict, ignored_dict)``.
     Raises ``FileNotFoundError`` if the config file doesn't exist.
     """
     if path.is_dir():
@@ -196,4 +222,4 @@ def read_venv_config(path: Path) -> tuple[dict[str, str | bool], dict[str, str]]
         raise FileNotFoundError(path)
     with open(path, "rb") as f:
         data = tomli.load(f)
-    return data.get("args", {}), data.get("metadata", {})
+    return data.get("args", {}), data.get("metadata", {}), data.get("requirements", {}), data.get("ignored", {})

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from odoo_venv.cli.main import app
+from odoo_venv.main import VenvResult
 from odoo_venv.utils import write_venv_config
 
 runner = CliRunner()
@@ -49,6 +50,7 @@ class TestUpdateCommand:
         def _side_effect(**kwargs):
             tmp_venv.mkdir(exist_ok=True)
             (tmp_venv / "pyvenv.cfg").write_text("uv = 0.7.0\n")
+            return VenvResult()
 
         mock_create.side_effect = _side_effect
         # Confirm the interactive prompt with "y"
@@ -76,6 +78,7 @@ class TestUpdateCommand:
         def _side_effect(**kwargs):
             tmp_venv.mkdir(exist_ok=True)
             (tmp_venv / "pyvenv.cfg").write_text("uv = 0.7.0\n")
+            return VenvResult()
 
         mock_create.side_effect = _side_effect
         result = runner.invoke(app, ["update", str(venv_dir), "--backup"], input="y\n")
@@ -92,6 +95,7 @@ class TestUpdateCommand:
         def _side_effect(**kwargs):
             tmp_venv.mkdir(exist_ok=True)
             (tmp_venv / "pyvenv.cfg").write_text("uv = 0.7.0\n")
+            return VenvResult()
 
         mock_create.side_effect = _side_effect
         result = runner.invoke(app, ["update", str(venv_dir), "--no-backup"], input="y\n")
@@ -108,6 +112,7 @@ class TestUpdateCommand:
         def _side_effect(**kwargs):
             tmp_venv.mkdir(exist_ok=True)
             (tmp_venv / "pyvenv.cfg").write_text("uv = 0.7.0\n")
+            return VenvResult()
 
         mock_create.side_effect = _side_effect
         result = runner.invoke(app, ["update", str(venv_dir)], input="n\n")


### PR DESCRIPTION
## Summary

Adds a `show` command and requirement origin tracking to `.odoo-venv.toml`.

## Changes

- **`show` command**: renders a Rich-formatted summary of any venv — config panel, packages grouped by origin, ignored packages table with reasons; `--no-transitive` flag hides transitive-only packages
- **Origin tracking**: `create_odoo_venv` now records where each package came from (`odoo`, `addons_dir:`, `manifest:`, `extra_requirement`, `transitive:parent`, etc.) and why packages were skipped (`explicit_ignore`, `auto_override`, `install_failure`, …); returns a `VenvResult` dataclass
- **TOML persistence**: `write_venv_config` / `read_venv_config` gain optional `[requirements]` and `[ignored]` sections; `create` and `update` commands write them automatically
- **`_process_requirement_line`**: returns `(written: bool, pkg_name: str | None)` instead of `bool`

## Test plan

- [x] `make check` passes
- [x] `make test` passes
- [x] `odoo-venv create ...` writes `[requirements]` and `[ignored]` to `.odoo-venv.toml`
- [x] `odoo-venv show .venv` renders config + packages + ignored table
- [x] `odoo-venv show .venv --no-transitive` hides transitive deps
- [x] `odoo-venv show` on old venv shows "No requirement origin data available"