### PR TITLE
fix(presets): pin setuptools<82.0 for Python 3.10 on Odoo 18.0+

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -103,6 +103,12 @@ command = ["uv", "pip", "install", "setuptools<82.0"]
 when = "odoo_version > '13.0' and odoo_version <= '17.0'"
 stage = "after_requirements"
 
+# setuptools>=82.0 breaks gevent==22.10.2 which we pin for Python 3.10
+[[common.extra_commands]]
+command = ["uv", "pip", "install", "setuptools<82.0"]
+when = "odoo_version > '17.0' and python_version == '3.10'"
+stage = "after_requirements"
+
 # Install cbor2==5.4.3 for Odoo >= 18.0
 # TMP: remove once proper fix is merged in odoo
 # See https://github.com/OCA/oca-ci/pull/119


### PR DESCRIPTION
## Summary
- Pin `setuptools<82.0` for Odoo 18.0+ when running on Python 3.10
- `setuptools>=82.0` is incompatible with `gevent==22.10.2` which we pin for Python 3.10
- Extends the existing setuptools constraint (Odoo 14.0–17.0) to also cover newer Odoo versions on Python 3.10

## Test plan
- [ ] Create a venv for Odoo 18.0 with Python 3.10 and verify setuptools < 82.0 is installed
- [ ] Verify existing Odoo 14.0–17.0 behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)