### PR TITLE
feat(e2e): add launcher smoke test to catch runtime dependency errors

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -131,6 +131,18 @@ jobs:
             --create-launcher \
             --skip-on-failure
 
+      - name: Start PostgreSQL
+        run: sudo systemctl start postgresql
+
+      - name: Ensure DB user
+        run: tlc --yes ensure-db-user
+
+      - name: Smoke-test Odoo launcher
+        run: |
+          version="${{ matrix.odoo_version }}"
+          major="${version%%.*}"
+          odoo-v${major} --workers=2 --stop-after-init
+
   test-oca:
     name: With OCA modules | Odoo ${{ matrix.odoo_version }} (Python ${{ matrix.python_version }})
     needs: test-native
@@ -241,3 +253,15 @@ jobs:
             --python-version ${{ matrix.python_version }} \
             --create-launcher \
             --addons-path=$addons_path
+
+      - name: Start PostgreSQL
+        run: sudo systemctl start postgresql
+
+      - name: Ensure DB user
+        run: tlc --yes ensure-db-user
+
+      - name: Smoke-test Odoo launcher
+        run: |
+          version="${{ matrix.odoo_version }}"
+          major="${version%%.*}"
+          odoo-v${major} --workers=2 --stop-after-init


### PR DESCRIPTION
## Summary
- Add a smoke test step to both `test-native` and `test-oca` e2e jobs
- Starts PostgreSQL, creates DB user, then runs the Odoo launcher with `--workers=2 --stop-after-init`
- Catches dependency errors (e.g. incompatible setuptools/gevent) that only surface at runtime, not at install time

## Test plan
- [ ] Verify all matrix combinations pass the new smoke test step
- [ ] Confirm launcher resolves correctly for `master` version (`odoo-vmaster`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)