### PR TITLE
Add project URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ authors = [
 ]
 requires-python = ">=3.10"
 license = "AGPL-3.0"
+
+[project.urls]
+Homepage = "https://trobz.github.io/odoo-venv/"
+Repository = "https://github.com/trobz/odoo-venv"
 license-files = ["LICENSE"]
 dependencies = [
     "typer",


### PR DESCRIPTION
## Summary
- Added `[project.urls]` section with Homepage and Repository links to pyproject.toml

## References
- Homepage: https://trobz.github.io/odoo-venv/
- Repository: https://github.com/trobz/odoo-venv