### PR TITLE
fix(presets): bump python-ldap to 3.4.2 for OpenLDAP 2.5+ compat

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -84,12 +84,18 @@ ignore_from_odoo_requirements = """
 gevent==21.8.0; sys_platform != 'win32' and python_version == '3.10',
 greenlet==1.1.2; sys_platform != 'win32' and python_version == '3.10',
 cbor2==5.4.2 ; python_version < '3.12',
-urllib3==1.26.5; python_version > '3.9' and python_version < '3.12'
+urllib3==1.26.5; python_version > '3.9' and python_version < '3.12',
+python-ldap==3.4.0 ; sys_platform != 'win32' and python_version < '3.12'
 """
+# python-ldap 3.4.0 fails on OpenLDAP 2.5+ (Arch, Fedora 36+, etc.)
+# because it hardcodes -lldap_r which was removed.
+# Bump to 3.4.2 which supports OpenLDAP 2.5+.
+# TMP: remove once https://github.com/odoo/odoo/pull/109217 is merged
 extra_requirement = """
 gevent==22.10.2; sys_platform == 'linux' and python_version == '3.10',
 greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10',
-urllib3==1.26.14; python_version > '3.9' and python_version < '3.12'
+urllib3==1.26.14; python_version > '3.9' and python_version < '3.12',
+python-ldap==3.4.2 ; sys_platform != 'win32' and python_version < '3.12'
 """
 
 # always ignore those exotic requirements unless explicitely added


### PR DESCRIPTION
## Summary
- Ignore Odoo's `python-ldap==3.4.0` pin and install `3.4.2` instead
- `python-ldap<=3.4.1` hardcodes `-lldap_r` which was removed in OpenLDAP 2.5+, causing build failures on Arch Linux, Fedora 36+, etc.

## References
- https://github.com/odoo/odoo/pull/109217 (upstream Odoo PR doing the same bump)
