### PR TITLE
feat: add list command to discover and display Odoo venvs

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -17,6 +18,7 @@ from odoo_addons_path import (
     get_odoo_version_from_release,
 )
 from rich.console import Console
+from rich.table import Table
 
 from odoo_venv.exceptions import PresetNotFoundError
 from odoo_venv.launcher import create_launcher
@@ -634,6 +636,32 @@ def _freeze_venv(venv_dir: Path) -> dict[str, str]:
             name, ver = line.split("==", 1)
             pkgs[re.sub(r"[-_.]+", "-", name).lower()] = ver
     return pkgs
+
+
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".tox", ".nox", ".mypy_cache", ".ruff_cache"}
+
+
+def _discover_venvs(root: Path) -> list[Path]:
+    venvs: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        if VENV_CONFIG_FILENAME in filenames:
+            venvs.append(Path(dirpath))
+            dirnames.clear()  # don't descend into venv internals
+    return sorted(venvs)
+
+
+def _read_venv_info(venv_dir: Path) -> dict[str, str]:
+    """Read display info from ``.odoo-venv.toml``.
+
+    Returns a dict with keys: ``python``, ``odoo``, ``preset``.
+    """
+    args, metadata, _requirements, _ignored = read_venv_config(venv_dir)
+    return {
+        "python": str(args.get("python_version", "")) or "N/A",
+        "odoo": metadata.get("odoo_version", "") or "N/A",
+        "preset": str(args.get("preset", "")),
+    }
 
 
 def _freeze_remote_venv(host: str, remote_path: str) -> dict[str, str]:
@@ -1305,3 +1333,28 @@ def show(
     if ignored:
         console.print()
         _print_ignored_panel(console, ignored)
+
+
+@app.command("list")
+def list_venvs():
+    """List virtual environments found under the current directory."""
+
+    root = Path.cwd()
+    venvs = _discover_venvs(root)
+
+    if not venvs:
+        typer.secho("No virtual environments found.", fg=typer.colors.YELLOW)
+        raise typer.Exit(0)
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("PATH")
+    table.add_column("PYTHON")
+    table.add_column("ODOO")
+    table.add_column("PRESET")
+
+    for venv_dir in venvs:
+        rel_path = f"./{venv_dir.relative_to(root)}"
+        info = _read_venv_info(venv_dir)
+        table.add_row(rel_path, info["python"], info["odoo"], info["preset"])
+
+    Console().print(table)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from odoo_venv.cli.main import (
+    _discover_venvs,
+    _read_venv_info,
+    app,
+)
+from odoo_venv.utils import write_venv_config
+
+runner = CliRunner()
+
+
+def _make_odoo_venv(path: Path, *, preset: str = "common", python: str = "3.10", odoo: str = "18.0"):
+    """Create a minimal odoo-venv directory with .odoo-venv.toml."""
+    path.mkdir(parents=True, exist_ok=True)
+    write_venv_config(path, {"preset": preset, "python_version": python}, odoo_version=odoo)
+
+
+# --- _discover_venvs ---
+
+
+def test_discover_venvs_finds_nested(tmp_path):
+    _make_odoo_venv(tmp_path / "proj" / ".venv")
+    _make_odoo_venv(tmp_path / "other" / "venv", odoo="17.0")
+
+    result = _discover_venvs(tmp_path)
+    assert len(result) == 2
+    assert tmp_path / "other" / "venv" in result
+    assert tmp_path / "proj" / ".venv" in result
+
+
+def test_discover_venvs_skips_noise_dirs(tmp_path):
+    for d in (".git", "node_modules", "__pycache__"):
+        _make_odoo_venv(tmp_path / d)
+
+    assert _discover_venvs(tmp_path) == []
+
+
+def test_discover_venvs_no_descend_into_venv(tmp_path):
+    """A nested venv inside another venv should not be discovered."""
+    _make_odoo_venv(tmp_path / ".venv")
+    _make_odoo_venv(tmp_path / ".venv" / "lib" / "nested_venv", odoo="17.0")
+
+    result = _discover_venvs(tmp_path)
+    assert result == [tmp_path / ".venv"]
+
+
+def test_discover_venvs_empty(tmp_path):
+    assert _discover_venvs(tmp_path) == []
+
+
+def test_discover_venvs_ignores_plain_venv(tmp_path):
+    """A plain venv (pyvenv.cfg only, no .odoo-venv.toml) should not appear."""
+    plain = tmp_path / ".venv"
+    plain.mkdir()
+    (plain / "pyvenv.cfg").write_text("version = 3.10.12\n")
+
+    assert _discover_venvs(tmp_path) == []
+
+
+# --- _read_venv_info ---
+
+
+def test_read_venv_info_from_config(tmp_path):
+    """All fields from .odoo-venv.toml in a single pass."""
+    write_venv_config(tmp_path, {"preset": "community", "python_version": "3.10"}, odoo_version="18.0")
+    info = _read_venv_info(tmp_path)
+    assert info == {"python": "3.10", "odoo": "18.0", "preset": "community"}
+
+
+# --- CLI integration ---
+
+
+def test_list_no_venvs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "No virtual environments found" in result.output
+
+
+def test_list_with_venvs_from_config(tmp_path, monkeypatch):
+    """Venv with .odoo-venv.toml shows all columns including PRESET."""
+    _make_odoo_venv(tmp_path / ".venv", preset="enterprise", python="3.10", odoo="18.0")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert ".venv" in result.output
+    assert "3.10" in result.output
+    assert "18.0" in result.output
+    assert "enterprise" in result.output


### PR DESCRIPTION
## Summary
- Implement `odoo-venv list` command for discovering and displaying virtual environments
- Recursively scans current directory for Python venvs
- Displays table with PATH, PYTHON version, and ODOO version
- Skips noise directories and avoids descending into venvs
