### PR TITLE
feat(cli): add `activate` command

### DIFF
--- a/odoo_venv/activate.py
+++ b/odoo_venv/activate.py
@@ -1,0 +1,127 @@
+"""Activate a virtual environment by spawning a new interactive shell.
+
+Uses os.execvpe() to replace the current process with a new shell that has
+the venv activated — the "pipenv fancy mode" pattern. Supports bash, zsh.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import tempfile
+from pathlib import Path
+
+import typer
+
+
+def detect_shell() -> tuple[str, str]:
+    """Detect the user's shell from $SHELL.
+
+    Returns:
+        (shell_name, shell_path) — e.g. ("bash", "/bin/bash").
+        Falls back to ("sh", "/bin/sh") when $SHELL is unset.
+    """
+    shell_path = os.environ.get("SHELL", "/bin/sh")
+    shell_name = Path(shell_path).name
+    return shell_name, shell_path
+
+
+def create_rcfile_bash(venv_path: Path) -> str:
+    """Create a temp rcfile that sources the user's bashrc + venv activate.
+
+    The rcfile deletes itself after being sourced so no temp files linger.
+
+    Args:
+        venv_path: Absolute path to the virtual environment directory.
+
+    Returns:
+        Path to the temporary rcfile.
+    """
+    bashrc = Path.home() / ".bashrc"
+    activate = venv_path / "bin" / "activate"
+
+    fd, rcfile = tempfile.mkstemp(prefix="odoo-venv-", suffix=".sh")
+    with os.fdopen(fd, "w") as f:
+        if bashrc.is_file():
+            f.write(f"source {shlex.quote(str(bashrc))}\n")
+        f.write(f"source {shlex.quote(str(activate))}\n")
+        # Self-cleanup: remove the temp file after it's been sourced
+        f.write(f"rm -f {shlex.quote(rcfile)}\n")
+    return rcfile
+
+
+def create_rcfile_zsh(venv_path: Path) -> str:
+    """Create a temp ZDOTDIR with .zshrc that sources user's zshrc + activate.
+
+    Zsh uses ZDOTDIR to locate .zshrc, so we create a temp directory containing
+    a .zshrc that chains the user's original config and the venv activation.
+
+    Args:
+        venv_path: Absolute path to the virtual environment directory.
+
+    Returns:
+        Path to the temporary ZDOTDIR directory.
+    """
+    zdotdir = tempfile.mkdtemp(prefix="odoo-venv-")
+    zshrc = Path(zdotdir) / ".zshrc"
+    user_zshrc = Path(os.environ.get("ZDOTDIR", str(Path.home()))) / ".zshrc"
+    activate = venv_path / "bin" / "activate"
+
+    with open(zshrc, "w") as f:
+        if user_zshrc.is_file():
+            f.write(f"source {shlex.quote(str(user_zshrc))}\n")
+        f.write(f"source {shlex.quote(str(activate))}\n")
+        # Restore original ZDOTDIR before cleanup so nested zsh works
+        original_zdotdir = os.environ.get("ZDOTDIR")
+        if original_zdotdir:
+            f.write(f"export ZDOTDIR={shlex.quote(original_zdotdir)}\n")
+        else:
+            f.write("unset ZDOTDIR\n")
+        # Self-cleanup: remove the temp ZDOTDIR after sourcing
+        f.write(f"rm -rf {shlex.quote(zdotdir)}\n")
+    return zdotdir
+
+
+def _clean_env() -> dict[str, str]:
+    """Return a copy of os.environ with any active venv deactivated.
+
+    Removes VIRTUAL_ENV and strips its bin/ directory from PATH so the
+    new shell starts clean — prevents PATH accumulation on nested activates.
+    """
+    env = os.environ.copy()
+    old_venv = env.pop("VIRTUAL_ENV", None)
+    if old_venv:
+        old_bin = str(Path(old_venv) / "bin")
+        env["PATH"] = os.pathsep.join(p for p in env.get("PATH", "").split(os.pathsep) if p != old_bin)
+    return env
+
+
+def activate_venv(venv_dir: Path) -> None:
+    """Spawn a new interactive shell with the venv activated.
+
+    Detects the user's shell, creates an appropriate rcfile, then replaces
+    the current process via os.execvpe(). This function never returns on success.
+
+    Args:
+        venv_dir: Absolute path to the virtual environment directory.
+    """
+    shell_name, shell_path = detect_shell()
+    env = _clean_env()
+
+    try:
+        if shell_name == "bash":
+            rcfile = create_rcfile_bash(venv_dir)
+            os.execvpe(shell_path, [shell_path, "--rcfile", rcfile, "-i"], env)  # noqa: S606
+        elif shell_name == "zsh":
+            zdotdir = create_rcfile_zsh(venv_dir)
+            env["ZDOTDIR"] = zdotdir
+            os.execvpe(shell_path, [shell_path, "-i"], env)  # noqa: S606
+        else:
+            activate = venv_dir / "bin" / "activate"
+            typer.secho(
+                f"Unsupported shell '{shell_name}'. Activate manually:\n  source {activate}", fg=typer.colors.YELLOW
+            )
+            raise typer.Exit(1)
+    except OSError as exc:
+        typer.secho(f"error: failed to start shell '{shell_path}': {exc}", fg=typer.colors.RED)
+        raise typer.Exit(1) from exc

--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -722,6 +722,21 @@ def compare(
 
 
 @app.command()
+def activate(
+    venv_dir: Annotated[str, typer.Option(help="Path to virtual environment.")] = "./.venv",
+):
+    """Activate a virtual environment (spawns a new shell)."""
+    from odoo_venv.activate import activate_venv
+
+    venv_path = Path(venv_dir).expanduser().resolve()
+    if not (venv_path / "bin" / "activate").is_file():
+        typer.secho(f"error: no venv found at {venv_path}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    activate_venv(venv_path)
+
+
+@app.command()
 def create_odoo_launcher(
     odoo_version: Annotated[str, typer.Argument(help="Odoo version, e.g: 19.0 or master")],
     venv_dir: Annotated[str, typer.Option(help="Path to the virtual environment.")],


### PR DESCRIPTION
## Situation: shell activation in the Python ecosystem

Activating a virtualenv is a daily friction point. Today's options:

| Tool | Command | Approach | Status / Known Issues |
|------|---------|----------|-----------------------|
| **Manual** | `source .venv/bin/activate` | User sources script in current shell | Verbose, easy to forget, varies by shell |
| **pipenv** | `pipenv shell` | PTY manipulation via pexpect (spawns subshell attached to a pseudo-terminal) | TTY echo regression in Docker — typed text becomes invisible (`pypa/pipenv#6572`) |
| **poetry** | `poetry shell` | Similar subshell spawning | Deprecated in Poetry 2.x — the team removed it, recommending `poetry env activate` which just prints the activate path |
| **uv** | *(none)* | — | Explicitly declined. 117+ comments on `astral-sh/uv#1910`; uv team says cross-shell PTY manipulation is unreliable — breaks with custom `.bashrc`, non-standard shells, Docker, WSL |
| **pixi** | `pixi shell` | Fake PTY that sends `source /tmp/activation.sh` to stdin | Documented edge cases with `.bashrc` customizations |

**The core problem:** you cannot `source` something *for* another process. Every approach that tries to modify the *current* shell from an external tool hits the same wall — PTY hacks, terminal state corruption, or shell-config interference. The uv and Poetry teams concluded this is fundamentally fragile and walked away from it.

## Why `odoo-venv activate` still makes sense

This project already manages the full venv lifecycle (creation, Odoo installation, requirement resolution, launcher scripts). The one gap: there's no quick way to drop into the venv for ad-hoc work — running `odoo-bin shell`, installing a debug package, or checking `pip list`.

The workaround (`source .venv/bin/activate`) works, but:
- It's inconsistent with the rest of the `odoo-venv` UX where everything is a single command
- Users have to remember different activation paths depending on their shell
- In projects with non-standard venv locations (`--venv-dir`), the path isn't obvious

## Approach

`os.execvpe()` replaces the current process with a new interactive shell that has the venv pre-activated via a temporary rcfile. No PTY manipulation, no subprocess overhead.

```
odoo-venv activate                    # activates .venv in CWD
odoo-venv activate --venv-dir /path   # activates specific venv
exit                                  # return to original shell
```

**Steps:** detect shell from `$SHELL` → create temp rcfile (sources user's shell config + venv activate) → `execvpe` with rcfile → rcfile self-deletes after sourcing.

**Shell support:** bash (`--rcfile`), zsh (temp `ZDOTDIR`), others (prints manual command).

**Nested activation:** `_clean_env()` strips `VIRTUAL_ENV` and its `bin/` from PATH before exec, preventing PATH accumulation when switching between venvs.

## Known limitations

- **bash-only `--rcfile`**: `bash --rcfile` creates a non-login interactive shell, skipping `~/.bash_profile`. Users who configure PATH/nvm/pyenv lose those in the activated shell.
- **bash/zsh only**: fish, nushell, PowerShell are unsupported — the fallback message prints a generic `source bin/activate`.
- **`$SHELL` in containers**: Docker images may have `$SHELL` unset or pointing to `/bin/sh`, triggering the unsupported-shell fallback even when bash is available.