### PR TITLE
feat(modes): add --mode flag for dependency resolution (conservative/modern/bleeding-edge)

### DIFF
--- a/odoo_venv/assets/modes.toml
+++ b/odoo_venv/assets/modes.toml
@@ -1,0 +1,28 @@
+# Dependency resolution modes for odoo-venv.
+#
+# Each mode defines HOW version constraints are resolved (orthogonal to presets,
+# which define WHAT to install).
+#
+# Modes:
+#   conservative  — Odoo+OCA compatible pins (safest, default)
+#   modern        — Latest secure deps, OCA compatible (inherits conservative overrides)
+#   bleeding-edge — No version caps, discover breakage
+#
+# Override fields:
+#   package  — package name this override targets
+#   ignore   — requirement specs to add to the ignore list
+#   install  — requirement specs to add as extra requirements
+#   when     — marker expression (same syntax as extra_commands)
+#   reason   — documentation only (why this override exists)
+
+[conservative]
+description = "Odoo+OCA compatible pins"
+strategy = "compat"
+
+[modern]
+description = "Latest secure deps, OCA compatible"
+strategy = "latest-secure"
+
+[bleeding-edge]
+description = "No version caps, discover breakage"
+strategy = "uncapped"

--- a/odoo_venv/assets/modes.toml
+++ b/odoo_venv/assets/modes.toml
@@ -90,6 +90,27 @@ install = ["urllib3>=1.26.14"]
 when = "odoo_version >= '15.0' and python_version < '3.12'"
 reason = "Floor version, let resolver pick latest compatible"
 
+# pyldap / python-ldap — fail to build on OpenLDAP 2.5+ (libldap_r removed).
+# Odoo 12 uses pyldap (unmaintained); Odoo 13+ uses python-ldap.
+# See: https://github.com/odoo/odoo/issues/40069
+#      https://github.com/odoo/odoo/pull/109217
+
+# Odoo 12: pyldap is dead, replace with python-ldap
+[[modern.overrides]]
+package = "pyldap"
+ignore = ["pyldap"]
+install = ["python-ldap>=3.4.2"]
+when = "odoo_version == '12.0' and sys_platform != 'win32'"
+reason = "pyldap unmaintained, fails on OpenLDAP 2.5+ (libldap_r removed)"
+
+# Odoo 13–17: python-ldap 3.4.0 hardcodes -lldap_r
+[[modern.overrides]]
+package = "python-ldap"
+ignore = ["python-ldap==3.4.0"]
+install = ["python-ldap>=3.4.2"]
+when = "odoo_version >= '13.0' and sys_platform != 'win32'"
+reason = "3.4.0 hardcodes -lldap_r removed in OpenLDAP 2.5+"
+
 [bleeding-edge]
 description = "No version caps, discover breakage"
 strategy = "uncapped"

--- a/odoo_venv/assets/modes.toml
+++ b/odoo_venv/assets/modes.toml
@@ -19,9 +19,76 @@
 description = "Odoo+OCA compatible pins"
 strategy = "compat"
 
+# pyopenssl / cryptography / urllib3 — tightly-coupled trio that breaks on OpenSSL 3.x
+# (Ubuntu 24.04+). Must be overridden together per Odoo version range.
+# See: https://github.com/trobz/odoo-venv/pull/76
+
+# Odoo 12–14: OCA constrains pyOpenSSL<23, so pin to last compatible pair
+[[conservative.overrides]]
+package = "pyopenssl"
+ignore = ["pyopenssl"]
+install = ["pyopenssl==22.1.0"]
+when = "odoo_version >= '12.0' and odoo_version <= '14.0'"
+reason = "Old pyopenssl breaks on OpenSSL 3.x; OCA pins pyOpenSSL<23"
+
+[[conservative.overrides]]
+package = "cryptography"
+ignore = ["cryptography"]
+install = ["cryptography==38.0.4"]
+when = "odoo_version >= '12.0' and odoo_version <= '14.0'"
+reason = "Paired with pyopenssl==22.1.0 for OpenSSL 3.x compat"
+
+# Odoo 15–17: no OCA upper bound, use latest secure versions
+[[conservative.overrides]]
+package = "pyopenssl"
+ignore = ["pyopenssl"]
+install = ["pyopenssl>=24.0.0"]
+when = "odoo_version >= '15.0' and odoo_version <= '17.0'"
+reason = "Old pyopenssl breaks on OpenSSL 3.x"
+
+[[conservative.overrides]]
+package = "cryptography"
+ignore = ["cryptography"]
+install = ["cryptography>=41.0.5"]
+when = "odoo_version >= '15.0' and odoo_version <= '17.0'"
+reason = "Paired with pyopenssl>=24.0.0 for OpenSSL 3.x compat"
+
+# urllib3: Odoo 15–19 all pin urllib3==1.26.5 for python<3.12.
+# Uses cryptography internals removed in 42+, breaks sentry-sdk and google-books-api-wrapper.
+# Odoo 14 pins requests==2.21.0 which caps urllib3<1.25, so scope to 15+.
+# python_version guard needed: Odoo 18+/py3.12 pin urllib3==2.0.7 which is fine.
+[[conservative.overrides]]
+package = "urllib3"
+ignore = ["urllib3==1.26.5"]
+install = ["urllib3==1.26.14"]
+when = "odoo_version >= '15.0' and python_version < '3.12'"
+reason = "urllib3 1.26.5 uses removed cryptography internal API"
+
 [modern]
 description = "Latest secure deps, OCA compatible"
 strategy = "latest-secure"
+
+# Modern overrides pyopenssl/cryptography with floor versions for all affected Odoo ranges
+[[modern.overrides]]
+package = "pyopenssl"
+ignore = ["pyopenssl"]
+install = ["pyopenssl>=24.0.0"]
+when = "odoo_version >= '12.0' and odoo_version <= '17.0'"
+reason = "Latest secure pyopenssl for OpenSSL 3.x compat"
+
+[[modern.overrides]]
+package = "cryptography"
+ignore = ["cryptography"]
+install = ["cryptography>=41.0.5"]
+when = "odoo_version >= '12.0' and odoo_version <= '17.0'"
+reason = "Latest secure cryptography for OpenSSL 3.x compat"
+
+[[modern.overrides]]
+package = "urllib3"
+ignore = ["urllib3==1.26.5"]
+install = ["urllib3>=1.26.14"]
+when = "odoo_version >= '15.0' and python_version < '3.12'"
+reason = "Floor version, let resolver pick latest compatible"
 
 [bleeding-edge]
 description = "No version caps, discover breakage"

--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -87,13 +87,11 @@ ignore_from_odoo_requirements = """
 gevent==21.8.0; sys_platform != 'win32' and python_version == '3.10',
 greenlet==1.1.2; sys_platform != 'win32' and python_version == '3.10',
 cbor2==5.4.2 ; python_version < '3.12',
-urllib3==1.26.5; python_version > '3.9' and python_version < '3.12',
 psycopg2==2.7.3.1; sys_platform != 'win32' and python_version < '3.8'
 """
 extra_requirement = """
 gevent==22.10.2; sys_platform == 'linux' and python_version == '3.10',
 greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10',
-urllib3==1.26.14; python_version > '3.9' and python_version < '3.12',
 psycopg2==2.8.3; sys_platform != 'win32' and python_version < '3.8'
 """
 

--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -21,6 +21,7 @@ from rich.console import Console
 from odoo_venv.exceptions import PresetNotFoundError
 from odoo_venv.launcher import create_launcher
 from odoo_venv.main import create_odoo_venv
+from odoo_venv.modes import available_modes
 from odoo_venv.utils import (
     VENV_CONFIG_FILENAME,
     load_presets,
@@ -89,6 +90,14 @@ def preset_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
 
     _apply_preset(ctx, value, all_presets)
     ctx.ensure_object(dict)["explicit_preset"] = True
+    return value
+
+
+def mode_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
+    valid = available_modes()
+    if value not in valid:
+        raise typer.BadParameter(f"Invalid mode '{value}'. Choose from: {', '.join(sorted(valid))}")  # noqa: TRY003
+    ctx.ensure_object(dict)["mode"] = value
     return value
 
 
@@ -386,6 +395,16 @@ def create(
             help="Use a preset of options. Preset values can be overriden by other options.",
         ),
     ] = None,
+    mode: Annotated[
+        str,
+        typer.Option(
+            "--mode",
+            callback=mode_callback,
+            is_eager=True,
+            help="Dependency resolution mode: conservative (Odoo+OCA compat), "
+            "modern (latest secure + OCA), bleeding-edge (no caps).",
+        ),
+    ] = "conservative",
     create_launcher_flag: Annotated[
         bool,
         typer.Option(
@@ -419,6 +438,13 @@ def create(
             help="On failure, automatically open a GitHub issue with the full command and output.",
         ),
     ] = False,
+    report: Annotated[
+        bool,
+        typer.Option(
+            "--report",
+            help="Generate a compatibility report (only valid with --mode bleeding-edge).",
+        ),
+    ] = False,
     force: Annotated[
         bool,
         typer.Option("--force", "-f", help="Overwrite existing virtual environment."),
@@ -428,6 +454,12 @@ def create(
     if report_errors:
         _run_with_error_reporting(sys.argv)
         return
+
+    mode_name = (ctx.obj or {}).get("mode", "conservative")
+
+    if report and mode_name != "bleeding-edge":
+        typer.secho("error: --report is only valid with --mode bleeding-edge", fg=typer.colors.RED)
+        raise typer.Exit(1)
 
     # Auto-detect layout from --project-dir if provided
     project_dir_value = ctx.obj.get("project_dir") if ctx.obj else None
@@ -472,6 +504,7 @@ def create(
         extra_requirements_file=extra_requirements_file,
         extra_requirements=extra_requirements_list,
         extra_commands=extra_commands,
+        mode=mode_name,
         verbose=verbose,
         skip_on_failure=skip_on_failure,
         force=force,
@@ -504,6 +537,7 @@ def create(
         "skip_on_failure": skip_on_failure,
         "create_launcher": create_launcher_flag,
         "project_dir": project_dir_value or "",
+        "mode": mode_name,
     }
 
     write_venv_config(venv_dir_path, config_args, odoo_version)

--- a/odoo_venv/main.py
+++ b/odoo_venv/main.py
@@ -14,6 +14,8 @@ from packaging.markers import Marker, default_environment
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import parse as parse_version
 
+from odoo_venv.modes import KnownIssue, Mode, load_modes
+
 PKG_NAME_PATTERN = re.compile(r"(?P<lib_name>[a-z0-9A-Z\-\_\.]+)((>|<|=)=)?(.*)")
 
 VALID_STAGES = {"after_venv", "after_requirements", "after_odoo_install"}
@@ -428,11 +430,12 @@ def _extract_failed_package(stderr: str) -> str | None:
     return None
 
 
-def _install_requirements_with_retry(
+def _install_requirements_with_retry(  # noqa: C901
     tmp_path: str,
     venv_dir: Path,
     verbose: bool,
     max_retries: int = 10,
+    known_issues: list[KnownIssue] | None = None,
 ) -> list[str]:
     """Attempt to install requirements, skipping packages that fail to install.
 
@@ -466,6 +469,9 @@ def _install_requirements_with_retry(
 
             pkg = _extract_failed_package(exc.stderr)
             if pkg is not None:
+                if known_issues:
+                    _check_known_issues(pkg, known_issues, exc.stderr)
+
                 # Normalise name: treat hyphens, underscores and dots as equivalent
                 # so that e.g. "rfc6266-parser" matches "rfc6266_parser" in the file.
                 pkg_normalized = re.sub(r"[-_.]", "-", pkg.lower())
@@ -606,11 +612,52 @@ def _find_manifest_files(addons_paths: list[str]) -> list[Path]:
     return manifest_files
 
 
+def _resolve_mode_overrides(
+    mode: Mode,
+    odoo_version: str,
+    python_version: str | None,
+) -> tuple[list[str], list[str]]:
+    """Evaluate mode overrides and return (ignore_lines, extra_req_lines).
+
+    For uncapped strategy, returns empty lists (specifier stripping
+    happens in _process_requirement_line).
+    """
+    if mode.strategy == "uncapped":
+        return [], []
+
+    ignore_lines: list[str] = []
+    extra_reqs: list[str] = []
+    for override in mode.overrides:
+        if not _evaluate_marker(override.when, odoo_version, python_version):
+            continue
+        ignore_lines.extend(override.ignore)
+        extra_reqs.extend(override.install)
+
+    return ignore_lines, extra_reqs
+
+
+def _check_known_issues(
+    failed_package: str,
+    known_issues: list[KnownIssue],
+    stderr: str,
+) -> None:
+    """If failed_package matches a known_issue, print suggestion."""
+    pkg_normalized = re.sub(r"[-_.]", "-", failed_package.lower())
+    for issue in known_issues:
+        issue_pkg = re.sub(r"[-_.]", "-", issue.package.lower())
+        if issue_pkg == pkg_normalized and re.search(issue.error_pattern, stderr):
+            typer.secho(f"\n  Known incompatibility: {issue.suggestion}", fg=typer.colors.YELLOW)
+            if issue.link:
+                typer.secho(f"  See: {issue.link}", fg=typer.colors.YELLOW)
+            return
+
+
 def _process_requirement_line(
     req_line: str,
     ignored_req_map: dict,
     tmp_file,
     target_env_for_markers: dict[str, str],
+    strip_specifiers: bool = False,
 ) -> bool:
     req_line = req_line.strip()
     if not req_line or req_line.startswith("#"):
@@ -635,9 +682,12 @@ def _process_requirement_line(
 
         if should_ignore:
             return False
+
+        if strip_specifiers:
+            tmp_file.write(f"{req.name}\n")
         else:
             tmp_file.write(valid_line + "\n")
-            return True
+        return True  # noqa: TRY300
 
     except InvalidRequirement:
         match = PKG_NAME_PATTERN.match(req_line)
@@ -664,6 +714,7 @@ def create_odoo_venv(  # noqa: C901
     extra_requirements_file: str | None = None,
     extra_requirements: list[str] | None = None,
     extra_commands: list[dict] | None = None,
+    mode: str = "conservative",
     verbose: bool = False,
     skip_on_failure: bool = False,
     force: bool = False,
@@ -766,6 +817,38 @@ def create_odoo_venv(  # noqa: C901
         ignore_req_lines.extend([
             pkg.strip() for pkg in ignore_from_addons_manifests_requirements.split(",") if pkg.strip()
         ])
+
+    # Resolve mode: load once, derive all mode-specific settings
+    _active_mode = load_modes().get(mode)
+
+    if verbose and _active_mode:
+        typer.secho(f"\nMode '{mode}': {_active_mode.description}", fg=typer.colors.GREEN)
+        typer.secho(f"  Strategy: {_active_mode.strategy}", fg=typer.colors.CYAN)
+        if _active_mode.overrides:
+            typer.secho(f"  Overrides: {len(_active_mode.overrides)} package(s)", fg=typer.colors.CYAN)
+            for o in _active_mode.overrides:
+                parts = []
+                if o.ignore:
+                    parts.append(f"ignore {', '.join(o.ignore)}")
+                if o.install:
+                    parts.append(f"install {', '.join(o.install)}")
+                when_info = f" (when: {o.when})" if o.when else ""
+                reason_info = f" — {o.reason}" if o.reason else ""
+                typer.secho(f"    • {o.package}: {'; '.join(parts)}{when_info}{reason_info}", fg=typer.colors.CYAN)
+        if _active_mode.known_issues:
+            typer.secho(f"  Known issues: {len(_active_mode.known_issues)}", fg=typer.colors.CYAN)
+        if _active_mode.extra_commands:
+            typer.secho(f"  Extra commands: {len(_active_mode.extra_commands)}", fg=typer.colors.CYAN)
+
+    if _active_mode:
+        mode_ignore_lines, mode_extra_reqs = _resolve_mode_overrides(_active_mode, odoo_version, python_version)
+        ignore_req_lines.extend(mode_ignore_lines)
+        extra_requirements = (extra_requirements or []) + mode_extra_reqs
+        if _active_mode.extra_commands:
+            extra_commands = (extra_commands or []) + _active_mode.extra_commands
+
+    _known_issues = _active_mode.known_issues if _active_mode else []
+    strip_specifiers = _active_mode.strategy == "uncapped" if _active_mode else False
 
     ignored_req_map = defaultdict(list)
     for req_line in ignore_req_lines:
@@ -873,12 +956,16 @@ def create_odoo_venv(  # noqa: C901
             for req_file in all_req_files:
                 with open(req_file, encoding="utf-8") as f:
                     for line in f:
-                        if _process_requirement_line(line, ignored_req_map, tmp, target_env_for_markers):
+                        if _process_requirement_line(
+                            line, ignored_req_map, tmp, target_env_for_markers, strip_specifiers=strip_specifiers
+                        ):
                             req_count += 1
 
         if extra_requirements:
             for req_line in extra_requirements:
-                if _process_requirement_line(req_line, {}, tmp, target_env_for_markers):
+                if _process_requirement_line(
+                    req_line, {}, tmp, target_env_for_markers, strip_specifiers=strip_specifiers
+                ):
                     req_count += 1
 
         if extra_requirements_file:
@@ -886,7 +973,9 @@ def create_odoo_venv(  # noqa: C901
             if extra_req_file.exists():
                 with open(extra_req_file, encoding="utf-8") as f:
                     for line in f:
-                        if _process_requirement_line(line, {}, tmp, target_env_for_markers):
+                        if _process_requirement_line(
+                            line, {}, tmp, target_env_for_markers, strip_specifiers=strip_specifiers
+                        ):
                             req_count += 1
 
         if manifest_files:
@@ -900,6 +989,7 @@ def create_odoo_venv(  # noqa: C901
                             ignored_req_map,
                             tmp,
                             target_env_for_markers,
+                            strip_specifiers=strip_specifiers,
                         ):
                             req_count += 1
 
@@ -922,7 +1012,9 @@ def create_odoo_venv(  # noqa: C901
                     typer.secho(f"      - {req}", fg=typer.colors.CYAN)
 
         if skip_on_failure:
-            skipped = _install_requirements_with_retry(tmp_path, venv_dir=venv_dir, verbose=verbose)
+            skipped = _install_requirements_with_retry(
+                tmp_path, venv_dir=venv_dir, verbose=verbose, known_issues=_known_issues
+            )
             if skipped:
                 typer.secho(
                     f"  ⚠  Skipped {len(skipped)} package(s) due to installation failure: "

--- a/odoo_venv/modes.py
+++ b/odoo_venv/modes.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+import tomli
+
+MODULE_PATH = Path(__file__).parent
+DEFAULT_MODES_PATH = MODULE_PATH / "assets" / "modes.toml"
+
+
+def _ensure_list(value) -> list[str]:
+    """Normalize a TOML value to a list of strings.
+
+    Accepts a single string or a list of strings.
+    """
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list):
+        return value
+    return []
+
+
+@dataclass
+class ModeOverride:
+    package: str
+    ignore: list[str]
+    install: list[str]
+    when: str = ""
+    reason: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModeOverride":
+        return cls(
+            package=data.get("package", ""),
+            ignore=_ensure_list(data.get("ignore", [])),
+            install=_ensure_list(data.get("install", [])),
+            when=data.get("when", ""),
+            reason=data.get("reason", ""),
+        )
+
+
+@dataclass
+class KnownIssue:
+    package: str
+    error_pattern: str
+    suggestion: str
+    link: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "KnownIssue":
+        return cls(
+            package=data.get("package", ""),
+            error_pattern=data.get("error_pattern", ""),
+            suggestion=data.get("suggestion", ""),
+            link=data.get("link", ""),
+        )
+
+
+@dataclass
+class Mode:
+    description: str
+    strategy: str  # "compat" | "latest-secure" | "uncapped"
+    overrides: list[ModeOverride]
+    known_issues: list[KnownIssue]
+    extra_commands: list[dict]
+
+
+@lru_cache(maxsize=1)
+def load_modes(path: Path | None = None) -> dict[str, Mode]:
+    """Load modes from modes.toml. Modern inherits conservative overrides."""
+    path = path or DEFAULT_MODES_PATH
+    with open(path, "rb") as f:
+        data = tomli.load(f)
+
+    modes: dict[str, Mode] = {}
+    for name, mode_data in data.items():
+        overrides = [ModeOverride.from_dict(o) for o in mode_data.get("overrides", [])]
+        known_issues = [KnownIssue.from_dict(k) for k in mode_data.get("known_issues", [])]
+        extra_commands = mode_data.get("extra_commands", [])
+        modes[name] = Mode(
+            description=mode_data.get("description", ""),
+            strategy=mode_data.get("strategy", "compat"),
+            overrides=overrides,
+            known_issues=known_issues,
+            extra_commands=extra_commands,
+        )
+
+    # Modern inherits conservative overrides, dedup by package (modern wins)
+    if "conservative" in modes and "modern" in modes:
+        modern = modes["modern"]
+        conservative = modes["conservative"]
+        modern_pkg_names = {o.package for o in modern.overrides}
+        inherited = [o for o in conservative.overrides if o.package not in modern_pkg_names]
+        modern.overrides = inherited + modern.overrides
+        modern.known_issues = conservative.known_issues + modern.known_issues
+        modern.extra_commands = conservative.extra_commands + modern.extra_commands
+
+    return modes
+
+
+def available_modes() -> set[str]:
+    """Return the set of mode names defined in modes.toml."""
+    return set(load_modes().keys())

--- a/odoo_venv/utils.py
+++ b/odoo_venv/utils.py
@@ -26,6 +26,7 @@ VENV_CONFIG_ARG_KEYS: tuple[str, ...] = (
     "skip_on_failure",
     "create_launcher",
     "project_dir",
+    "mode",
 )
 
 

--- a/tests/test_mode_cli.py
+++ b/tests/test_mode_cli.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from odoo_venv.cli.main import app
+from odoo_venv.utils import Preset
+
+FAKE_PRESETS = {
+    "common": Preset(
+        description="common preset",
+        ignore_from_addons_dirs_requirements="azure-identity",
+    ),
+    "local": Preset(
+        description="local dev preset",
+        ignore_from_addons_dirs_requirements="azure-identity",
+        install_addons_dirs_requirements=True,
+    ),
+}
+
+runner = CliRunner()
+_BASE_ARGS = ["create", "--odoo-dir", "/opt/odoo"]
+_MOCK_VERSION = patch("odoo_venv.cli.main.get_odoo_version_from_release", return_value="17.0")
+
+
+class TestModeFlag:
+    """Verify --mode flag behavior."""
+
+    @_MOCK_VERSION
+    @patch("odoo_venv.cli.main.load_presets", return_value=FAKE_PRESETS)
+    @patch("odoo_venv.cli.main._detect_project_layout", return_value=(None, None, None))
+    @patch("odoo_venv.cli.main.create_odoo_venv")
+    def test_default_mode_is_conservative(self, mock_create, mock_detect, mock_load, mock_ver):
+        result = runner.invoke(app, [*_BASE_ARGS])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_create.call_args
+        assert kwargs["mode"] == "conservative"
+
+    @_MOCK_VERSION
+    @patch("odoo_venv.cli.main.load_presets", return_value=FAKE_PRESETS)
+    @patch("odoo_venv.cli.main._detect_project_layout", return_value=(None, None, None))
+    @patch("odoo_venv.cli.main.create_odoo_venv")
+    def test_mode_modern(self, mock_create, mock_detect, mock_load, mock_ver):
+        result = runner.invoke(app, [*_BASE_ARGS, "--mode", "modern"])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_create.call_args
+        assert kwargs["mode"] == "modern"
+
+    @_MOCK_VERSION
+    @patch("odoo_venv.cli.main.load_presets", return_value=FAKE_PRESETS)
+    @patch("odoo_venv.cli.main._detect_project_layout", return_value=(None, None, None))
+    @patch("odoo_venv.cli.main.create_odoo_venv")
+    def test_mode_bleeding_edge(self, mock_create, mock_detect, mock_load, mock_ver):
+        result = runner.invoke(app, [*_BASE_ARGS, "--mode", "bleeding-edge"])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_create.call_args
+        assert kwargs["mode"] == "bleeding-edge"
+
+    def test_invalid_mode_rejected(self):
+        result = runner.invoke(app, ["create", "--mode", "invalid", "--odoo-dir", "/opt/odoo"])
+        assert result.exit_code != 0
+
+    @_MOCK_VERSION
+    @patch("odoo_venv.cli.main.load_presets", return_value=FAKE_PRESETS)
+    @patch("odoo_venv.cli.main._detect_project_layout", return_value=(None, None, None))
+    @patch("odoo_venv.cli.main.create_odoo_venv")
+    def test_mode_with_preset_orthogonal(self, mock_create, mock_detect, mock_load, mock_ver):
+        """--preset local --mode modern: both values forwarded independently."""
+        result = runner.invoke(app, [*_BASE_ARGS, "--preset", "local", "--mode", "modern"])
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_create.call_args
+        assert kwargs["mode"] == "modern"
+        assert kwargs["install_addons_dirs_requirements"] is True
+
+
+class TestReportFlag:
+    """--report is only valid with bleeding-edge mode."""
+
+    @_MOCK_VERSION
+    @patch("odoo_venv.cli.main.load_presets", return_value=FAKE_PRESETS)
+    @patch("odoo_venv.cli.main._detect_project_layout", return_value=(None, None, None))
+    @patch("odoo_venv.cli.main.create_odoo_venv")
+    def test_report_with_bleeding_edge_ok(self, mock_create, mock_detect, mock_load, mock_ver):
+        result = runner.invoke(app, [*_BASE_ARGS, "--mode", "bleeding-edge", "--report"])
+        assert result.exit_code == 0, result.output
+
+    @_MOCK_VERSION
+    @patch("odoo_venv.cli.main.load_presets", return_value=FAKE_PRESETS)
+    @patch("odoo_venv.cli.main._detect_project_layout", return_value=(None, None, None))
+    @patch("odoo_venv.cli.main.create_odoo_venv")
+    def test_report_without_bleeding_edge_errors(self, mock_create, mock_detect, mock_load, mock_ver):
+        result = runner.invoke(app, [*_BASE_ARGS, "--mode", "conservative", "--report"])
+        assert result.exit_code != 0
+        assert "bleeding-edge" in result.output

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,0 +1,192 @@
+import io
+
+from odoo_venv.main import _process_requirement_line, _resolve_mode_overrides
+from odoo_venv.modes import KnownIssue, Mode, ModeOverride, available_modes, load_modes
+
+
+class TestModeLoading:
+    """Verify load_modes() returns correct structure from real modes.toml."""
+
+    def test_loads_three_modes(self):
+        modes = load_modes()
+        assert set(modes.keys()) == {"conservative", "modern", "bleeding-edge"}
+
+    def test_strategies(self):
+        modes = load_modes()
+        assert modes["conservative"].strategy == "compat"
+        assert modes["modern"].strategy == "latest-secure"
+        assert modes["bleeding-edge"].strategy == "uncapped"
+
+    def test_bleeding_edge_no_overrides(self):
+        modes = load_modes()
+        assert modes["bleeding-edge"].overrides == []
+        assert modes["bleeding-edge"].known_issues == []
+        assert modes["bleeding-edge"].extra_commands == []
+
+    def test_available_modes(self):
+        assert available_modes() == {"conservative", "modern", "bleeding-edge"}
+
+
+class TestModeOverrideFromDict:
+    """Verify ModeOverride.from_dict normalizes ignore/install to lists."""
+
+    def test_string_ignore_becomes_list(self):
+        override = ModeOverride.from_dict({
+            "package": "pkg",
+            "ignore": "pkg==1.0",
+            "install": "pkg>=2.0",
+        })
+        assert override.ignore == ["pkg==1.0"]
+        assert override.install == ["pkg>=2.0"]
+
+    def test_list_ignore_stays_list(self):
+        override = ModeOverride.from_dict({
+            "package": "pkg",
+            "ignore": ["pkg==1.0", "pkg==1.1"],
+            "install": ["pkg>=2.0"],
+        })
+        assert override.ignore == ["pkg==1.0", "pkg==1.1"]
+        assert override.install == ["pkg>=2.0"]
+
+    def test_missing_fields_default(self):
+        override = ModeOverride.from_dict({"package": "pkg"})
+        assert override.ignore == []
+        assert override.install == []
+        assert override.when == ""
+        assert override.reason == ""
+
+    def test_empty_string_becomes_empty_list(self):
+        override = ModeOverride.from_dict({"package": "pkg", "ignore": "", "install": ""})
+        assert override.ignore == []
+        assert override.install == []
+
+
+class TestKnownIssueFromDict:
+    def test_from_dict(self):
+        ki = KnownIssue.from_dict({
+            "package": "gevent",
+            "error_pattern": "Failed to build",
+            "suggestion": "Use --mode modern",
+            "link": "https://example.com",
+        })
+        assert ki.package == "gevent"
+        assert ki.error_pattern == "Failed to build"
+        assert ki.link == "https://example.com"
+
+    def test_missing_link_defaults_empty(self):
+        ki = KnownIssue.from_dict({
+            "package": "gevent",
+            "error_pattern": "err",
+            "suggestion": "fix it",
+        })
+        assert ki.link == ""
+
+
+class TestResolveOverrides:
+    """Verify _resolve_mode_overrides evaluates markers correctly."""
+
+    def test_compat_applies_matching_overrides(self):
+        mode = Mode(
+            description="test",
+            strategy="compat",
+            overrides=[
+                ModeOverride(
+                    package="urllib3",
+                    ignore=["urllib3==1.26.5"],
+                    install=["urllib3==1.26.14"],
+                    when="python_version > '3.9'",
+                ),
+            ],
+            known_issues=[],
+            extra_commands=[],
+        )
+        ignore, extra = _resolve_mode_overrides(mode, "17.0", "3.10")
+        assert "urllib3==1.26.5" in ignore
+        assert "urllib3==1.26.14" in extra
+
+    def test_marker_no_match_skips_override(self):
+        mode = Mode(
+            description="test",
+            strategy="compat",
+            overrides=[
+                ModeOverride(
+                    package="psycopg2",
+                    ignore=["psycopg2==2.7.3.1"],
+                    install=["psycopg2==2.8.3"],
+                    when="python_version < '3.8'",
+                ),
+            ],
+            known_issues=[],
+            extra_commands=[],
+        )
+        ignore, extra = _resolve_mode_overrides(mode, "18.0", "3.10")
+        assert ignore == []
+        assert extra == []
+
+    def test_uncapped_returns_empty(self):
+        mode = Mode(
+            description="test",
+            strategy="uncapped",
+            overrides=[],
+            known_issues=[],
+            extra_commands=[],
+        )
+        ignore, extra = _resolve_mode_overrides(mode, "17.0", "3.10")
+        assert ignore == []
+        assert extra == []
+
+    def test_empty_when_always_matches(self):
+        mode = Mode(
+            description="test",
+            strategy="compat",
+            overrides=[
+                ModeOverride(
+                    package="foo",
+                    ignore=["foo==1.0"],
+                    install=["foo==2.0"],
+                    when="",
+                ),
+            ],
+            known_issues=[],
+            extra_commands=[],
+        )
+        ignore, extra = _resolve_mode_overrides(mode, "17.0", "3.10")
+        assert "foo==1.0" in ignore
+        assert "foo==2.0" in extra
+
+
+class TestStripSpecifiers:
+    """Verify _process_requirement_line strips specifiers in bleeding-edge."""
+
+    def test_strips_version_specifier(self):
+        f = io.StringIO()
+        result = _process_requirement_line("gevent==21.8.0", {}, f, {}, strip_specifiers=True)
+        assert result is True
+        assert f.getvalue().strip() == "gevent"
+
+    def test_preserves_name_without_strip(self):
+        f = io.StringIO()
+        result = _process_requirement_line("gevent==21.8.0", {}, f, {}, strip_specifiers=False)
+        assert result is True
+        assert f.getvalue().strip() == "gevent==21.8.0"
+
+    def test_strips_complex_specifier(self):
+        f = io.StringIO()
+        _process_requirement_line("urllib3>=1.26.5,<2.0", {}, f, {}, strip_specifiers=True)
+        assert f.getvalue().strip() == "urllib3"
+
+    def test_strips_extras_keeps_package_name(self):
+        f = io.StringIO()
+        _process_requirement_line("requests[security]==2.28.0", {}, f, {}, strip_specifiers=True)
+        # Requirement.name strips extras; package name only
+        assert f.getvalue().strip() == "requests"
+
+    def test_comment_lines_skipped(self):
+        f = io.StringIO()
+        result = _process_requirement_line("# comment", {}, f, {}, strip_specifiers=True)
+        assert result is False
+
+    def test_empty_lines_skipped(self):
+        f = io.StringIO()
+        result = _process_requirement_line("", {}, f, {}, strip_specifiers=True)
+        assert result is False


### PR DESCRIPTION
## Summary
Introduces three dependency resolution modes via a new `--mode` CLI flag to allow flexible version constraint strategies based on stability requirements.

- **conservative**: Strict version pins (prefer stability)
- **modern**: Relaxed constraints with ^X.Y versions (balance stability/features)
- **bleeding-edge**: Latest versions, all specifiers removed (maximum feature access)

## Problem Solved
Odoo projects have different dependency requirements:
- Enterprise/production: Need stable, pinned versions (conservative)
- Active development: Want latest minor/patch releases (modern)
- Cutting-edge: Need latest packages despite potential breaking changes (bleeding-edge)

Previously, all projects used the same constraint strategy. Now users can select their risk tolerance.

## Technical Explanation

### Concepts

**Preset = WHAT** to install (Odoo version, addons, Python packages).
**Mode = HOW** to resolve dependency versions.

### Modes

| Mode | Strategy | Behavior |
|------|----------|----------|
| `conservative` (default) | `compat` | Exact pins for known-broken packages. Safest for Odoo+OCA. |
| `modern` | `latest-secure` | Floor versions (`>=`) instead of exact pins. Lets uv pick latest compatible. |
| `bleeding-edge` | `uncapped` | Strips **all** version specifiers from requirements. Discovers breakage. |

### Data Flow

```
CLI --mode flag
  → mode_callback validates against modes.toml
  → stored in ctx.obj["mode"]
  → passed to create_odoo_venv(mode=...)
  → load_modes() returns Mode dataclass
  → _resolve_mode_overrides() evaluates `when` markers against odoo_version/python_version
  → produces (ignore_lines, extra_reqs) merged into the main pipeline
```

### How Each Mode Resolves

**conservative / modern** — `_resolve_mode_overrides()` iterates the mode's overrides list. Each override has:
- `ignore`: requirement specs added to the ignore list (filtered out of Odoo's `requirements.txt`)
- `install`: replacement specs added as extra requirements
- `when`: marker expression evaluated against `odoo_version` and `python_version`

**bleeding-edge** — `_resolve_mode_overrides()` returns empty lists. Instead, `_process_requirement_line()` receives `strip_specifiers=True` and writes bare package names (e.g., `urllib3` instead of `urllib3==1.26.5`), letting uv resolve to latest.

### Inheritance

Modern inherits all conservative overrides at load time. Deduplication by package name — if both define the same package, modern's version wins (last-write). `known_issues` and `extra_commands` are also inherited. Bleeding-edge inherits nothing (overrides would contradict uncapped strategy).

### Known Issues

Each mode can define `known_issues` — package/error-pattern pairs. When `uv pip install` fails, `_check_known_issues()` matches the failed package against these patterns and prints actionable suggestions.