### PR TITLE
feat(presets): add click-odoo-contrib dependency to all presets

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -94,7 +94,8 @@ extra_requirement = """
 gevent==22.10.2; sys_platform == 'linux' and python_version == '3.10',
 greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10',
 urllib3==1.26.14; python_version > '3.9' and python_version < '3.12',
-psycopg2==2.8.3; sys_platform != 'win32' and python_version < '3.8'
+psycopg2==2.8.3; sys_platform != 'win32' and python_version < '3.8',
+click-odoo-contrib==1.23.1
 """
 
 # always ignore those exotic requirements unless explicitely added


### PR DESCRIPTION
`click-odoo` needs to run in the same venv as odoo.

Forge ID: F#T67348