### PR TITLE
feat: add ovx command for on-the-fly Odoo module runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,15 @@
 odoo_venv/
 ├── cli/
 │   ├── __init__.py
-│   └── main.py          — CLI entry point (Typer app, commands: create, create-odoo-launcher)
+│   ├── main.py          — CLI entry point (Typer app, commands: create, create-odoo-launcher)
+│   └── ovx_cmd.py       — Standalone `ovx` Typer app (delegates to ovx.py)
 ├── assets/              — Bundled presets.toml and launcher.sh.template
 ├── main.py              — Core logic: venv creation, requirement resolution, Odoo installation
+├── ovx.py               — ovx orchestrator: run_ovx, build_odoo_argv, DB lifecycle
+├── ovx_resolver.py      — Venv resolution and clone primitives for ovx
 ├── utils.py             — Preset loading/merging, config paths
 ├── launcher.py          — Generates ~/.local/bin/odoo-vXX launcher scripts
-└── exceptions.py        — Custom exceptions
+└── exceptions.py        — Custom exceptions (PresetNotFoundError, OdooVenvError)
 ```
 
 ## Key Concepts
@@ -30,6 +33,7 @@ odoo_venv/
 - **Presets**: TOML-based option bundles bundled with the tool; a `[common]` section merges into all other presets by default
 - **Extra commands**: Preset-defined shell commands that run at stages: `after_venv`, `after_requirements`, `after_odoo_install`; support `when` markers with `odoo_version` and PEP 508 expressions
 - **Requirement filtering**: Processes Odoo's `requirements.txt`, addons dirs, and manifest `external_dependencies`; supports ignoring specific packages via comma-separated lists
+- **ovx**: Standalone `ovx ADDON_PATHS` command (separate script entry point, not a subcommand of `odoo-venv`). Accepts a comma-separated list of addon paths (e.g. `ovx ./a,~/oca/b`); the first addon's manifest decides the Odoo series — mismatched modules fail at Odoo's module-not-found error; paths containing commas are not supported. Detects Odoo series from `__manifest__.py`, resolves/clones a matching venv, installs missing Python deps (union across all manifests, deduped), runs Odoo with `-i <module_a>,<module_b>`, and manages an ephemeral DB lifecycle (name joins all module names). Accepts `--addons-path` (CSV) to merge extra paths (e.g. enterprise/OCA) into the venv's stored `addons_path`; also passed to `create_odoo_venv` on fresh-venv creation. Source: `ovx.py` (orchestrator) + `ovx_resolver.py` (resolution/clone) + `cli/ovx_cmd.py` (CLI).
 
 ## Dev Commands
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,51 @@ create_odoo_venv(
 )
 ```
 
+## ovx — on-the-fly module runner
+
+`ovx` is a companion command that runs an Odoo addon instantly — like `npx`/`uvx` for Odoo. It detects the required Odoo series from the addon's `__manifest__.py`, finds or creates a matching venv, installs any missing Python dependencies, and launches Odoo with `-i <module>`. The database is ephemeral by default and is dropped on exit.
+
+Multiple addons can be passed as a comma-separated list. The first addon's manifest decides the Odoo series; mismatched modules will fail at Odoo's module-not-found error. Paths containing commas are not supported.
+
+```bash
+# Auto-discover a matching venv in the current directory:
+ovx ./crm_eav_fields
+
+# Run multiple addons in a single ephemeral DB:
+ovx ./module_a,~/oca/module_b
+
+# Explicit venv:
+ovx ./crm_eav_fields --venv-dir ~/code/foo/.venv
+
+# Fresh-create a venv (requires Odoo source):
+ovx ./crm_eav_fields --odoo-dir ~/code/odoo/19.0
+
+# Named, persistent database (not dropped on exit):
+ovx ./crm_eav_fields -d my_dev_db
+
+# Pass extra arguments through to Odoo:
+ovx ./crm_eav_fields -- --log-level=debug --workers 0
+
+# Extra addons paths (e.g. enterprise/OCA) merged with the venv's stored addons_path:
+ovx ./my-addon --odoo-dir ~/odoo --addons-path ~/enterprise,~/oca/server-tools
+```
+
+> **`--addons-path`** accepts a comma-separated list of extra paths. They are merged with the venv's stored `addons_path` and the addon's own parent directory (deduped, order preserved). When no venv is found and a fresh one is created, the paths are also passed to `create_odoo_venv` so Python deps declared in enterprise/OCA manifests are installed during venv build.
+
+### Venv resolution priority
+
+| Priority | Condition | Outcome |
+|----------|-----------|---------|
+| 1 | `--venv-dir` provided | Use it; error if Odoo version mismatches |
+| 2 | Exactly one venv found under CWD matching the addon's series | Use it |
+| 3 | Multiple matches | Error — pass `--venv-dir` to disambiguate |
+| 4 | No match, `--odoo-dir` provided | Create a fresh venv |
+| 5 | No match, no `--odoo-dir` | Error |
+
+### Database lifecycle
+
+By default `ovx` generates a unique ephemeral DB name (`ovx_<joined_modules>_<hex8>`) and drops it when Odoo exits — even on Ctrl-C or non-zero exit. Pass `-d <name>` to use a named, persistent database instead (no automatic create or drop).
+
 ## Development
 
 To test with a clean state (no cached packages):

--- a/odoo_venv/cli/ovx_cmd.py
+++ b/odoo_venv/cli/ovx_cmd.py
@@ -1,0 +1,86 @@
+"""Standalone CLI entry point for the `ovx` command."""
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from odoo_venv.exceptions import OdooVenvError
+from odoo_venv.ovx import run_ovx
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def main(
+    ctx: typer.Context,
+    addon_paths: Annotated[
+        str,
+        typer.Argument(help="Comma-separated paths to Odoo addon directories (e.g. ./a,~/oca/b)."),
+    ],
+    venv_dir: Annotated[
+        Path | None,
+        typer.Option("--venv-dir", help="Explicit venv to use (must match addon's Odoo series)."),
+    ] = None,
+    odoo_dir: Annotated[
+        Path | None,
+        typer.Option("--odoo-dir", help="Odoo source directory (required when creating a fresh venv)."),
+    ] = None,
+    database: Annotated[
+        str | None,
+        typer.Option("-d", "--database", help="Named DB to use. Suppresses ephemeral DB creation and cleanup."),
+    ] = None,
+    keep_clone: Annotated[
+        bool,
+        typer.Option("--keep-clone", hidden=True, help="Keep the cloned venv on disk after run."),
+    ] = False,
+    no_launcher: Annotated[
+        bool,
+        typer.Option("--no-launcher", help="Skip launcher script creation."),
+    ] = False,
+    addons_path: Annotated[
+        str | None,
+        typer.Option(
+            "--addons-path", help="Extra addons paths (comma-separated) for modules the target addon depends on."
+        ),
+    ] = None,
+):
+    """Run an Odoo addon on-the-fly — like npx/uvx but for Odoo.
+
+    Detects the addon's Odoo series from __manifest__.py, resolves or creates
+    a matching venv, installs missing Python dependencies, then runs Odoo with
+    `-i <module>`. The database is ephemeral by default (dropped on exit); pass
+    -d <name> to use a named, persistent database.
+
+    Multiple addons can be passed as a comma-separated list (e.g. ./a,~/oca/b).
+    The first addon's manifest decides the Odoo series; mismatched modules will
+    fail at Odoo's module-not-found error. Paths containing commas are not supported.
+
+    Extra arguments after -- are forwarded verbatim to Odoo.
+    """
+    parts = [p.strip() for p in addon_paths.split(",")]
+    if any(not p for p in parts):
+        raise typer.BadParameter("Empty path entry in comma-separated addon_paths.", param_hint="addon_paths")  # noqa: TRY003
+    resolved_paths = [Path(p).expanduser().resolve() for p in parts]
+
+    extra_addons: list[str] = []
+    if addons_path:
+        extra_addons = [str(Path(p.strip()).expanduser().resolve()) for p in addons_path.split(",") if p.strip()]
+    try:
+        rc = run_ovx(
+            resolved_paths,
+            venv_dir=venv_dir,
+            odoo_dir=odoo_dir,
+            database=database,
+            keep_clone=keep_clone,
+            no_launcher=no_launcher,
+            extra_args=ctx.args,
+            cwd=Path.cwd(),
+            addons_path=extra_addons,
+        )
+        raise typer.Exit(rc)
+    except OdooVenvError as exc:
+        typer.secho(f"error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from None

--- a/odoo_venv/exceptions.py
+++ b/odoo_venv/exceptions.py
@@ -4,3 +4,7 @@ from typer import BadParameter
 class PresetNotFoundError(BadParameter):
     def __init__(self, preset: str) -> None:
         super().__init__(f"Preset '{preset}' not found.")
+
+
+class OdooVenvError(Exception):
+    """General error raised by ovx operations."""

--- a/odoo_venv/ovx.py
+++ b/odoo_venv/ovx.py
@@ -1,0 +1,263 @@
+"""Orchestrator and DB lifecycle for the ovx command."""
+
+import ast
+import contextlib
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+import typer
+
+from odoo_venv.exceptions import OdooVenvError
+from odoo_venv.launcher import create_launcher
+from odoo_venv.main import create_odoo_venv
+from odoo_venv.ovx_resolver import (
+    ResolvedVenv,
+    clone_venv,
+    get_addon_series,
+    install_missing_python_deps,
+    resolve_base_venv,
+)
+from odoo_venv.utils import read_venv_config
+
+
+def user_supplied_db(extra_args: list[str]) -> bool:
+    """Return True if the user passed -d / --database in extra_args."""
+    for arg in extra_args:
+        if arg in ("-d", "--database"):
+            return True
+        if arg.startswith("--database="):
+            return True
+    return False
+
+
+def build_odoo_argv(
+    venv: Path,
+    addon_paths: list[Path],
+    addons_path: list[str],
+    db_name: str,
+    extra_args: list[str],
+) -> list[str]:
+    """Build the Odoo subprocess argv list."""
+    modules = ",".join(p.name for p in addon_paths)
+    joined = ",".join(addons_path) if addons_path else str(addon_paths[0].parent)
+    return [
+        str(venv / "bin" / "python"),
+        "-m",
+        "odoo",
+        "-i",
+        modules,
+        "--addons-path",
+        joined,
+        "-d",
+        db_name,
+        *extra_args,
+    ]
+
+
+def make_ephemeral_db_name(names: list[str]) -> str:
+    """Generate a unique ephemeral DB name from addon directory names."""
+    sanitized_parts = [re.sub(r"[^a-z0-9_]", "_", n.lower()) for n in names]
+    joined = "_".join(sanitized_parts)[:50]
+    suffix = uuid.uuid4().hex[:8]
+    return f"ovx_{joined}_{suffix}"
+
+
+def _drop_db(name: str) -> None:
+    """Drop a Postgres database by name, silently ignoring failures."""
+    result = subprocess.run(  # noqa: S603
+        ["dropdb", "--if-exists", name],  # noqa: S607
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        subprocess.run(  # noqa: S603
+            ["psql", "-c", f'DROP DATABASE IF EXISTS "{name}";', "postgres"],  # noqa: S607
+            capture_output=True,
+        )
+
+
+def run_with_db_lifecycle(odoo_cmd: list[str], db_name: str | None) -> int:
+    """Spawn Odoo and manage ephemeral DB cleanup.
+
+    If *db_name* is not None, the DB is dropped after Odoo exits (success or failure).
+    If *db_name* is None, the caller manages the DB lifecycle (user-supplied -d).
+    """
+    managed = db_name is not None
+    proc = subprocess.Popen(odoo_cmd)  # noqa: S603
+
+    old_sigint = signal.getsignal(signal.SIGINT)
+    old_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def _forward(sig, _frame):
+        with contextlib.suppress(ProcessLookupError):
+            proc.send_signal(sig)
+
+    signal.signal(signal.SIGINT, _forward)
+    signal.signal(signal.SIGTERM, _forward)
+
+    try:
+        rc = proc.wait()
+    finally:
+        signal.signal(signal.SIGINT, old_sigint)
+        signal.signal(signal.SIGTERM, old_sigterm)
+        if managed and db_name is not None:
+            _drop_db(db_name)
+
+    return rc
+
+
+def _prepare_target(
+    resolved: ResolvedVenv,
+    addon_paths: list[Path],
+    series: str,
+    odoo_dir: Path | None,
+    keep_clone: bool,
+    extra_addons_paths: list[str] | None = None,
+) -> tuple[Path, "Callable[[], None] | None"]:
+    """Create or clone the working venv. Returns (target_path, cleanup_fn)."""
+    if resolved.fresh:
+        if odoo_dir is None:
+            raise OdooVenvError("--odoo-dir is required to create a fresh venv")  # noqa: TRY003
+        if keep_clone:
+            clone_dir = Path(tempfile.mkdtemp(prefix="ovx_fresh_"))
+            cleanup = None
+        else:
+            td = tempfile.TemporaryDirectory(prefix="ovx_fresh_")
+            clone_dir = Path(td.name)
+            cleanup = td.cleanup
+
+        target = clone_dir / f"odoo-{series}-venv"
+        typer.secho(f"Creating fresh venv at {target}...", fg=typer.colors.CYAN)
+        all_parents = list(dict.fromkeys([*(extra_addons_paths or []), *[str(p.parent) for p in addon_paths]]))
+        create_odoo_venv(
+            odoo_version=series,
+            odoo_dir=odoo_dir,
+            venv_dir=str(target),
+            python_version=None,
+            install_addons_manifests_requirements=True,
+            addons_paths=all_parents,
+        )
+        return target, cleanup
+
+    if resolved.path is None:
+        raise OdooVenvError("Internal error: resolved venv path is None")  # noqa: TRY003
+
+    if keep_clone:
+        clone_dir = Path(tempfile.mkdtemp(prefix="ovx_clone_"))
+        target = clone_dir / resolved.path.name
+        shutil.copytree(resolved.path, target, symlinks=True)
+        return target, None
+
+    target, cleanup = clone_venv(resolved.path)
+    return target, cleanup
+
+
+def run_ovx(
+    addon_paths: list[Path],
+    *,
+    venv_dir: Path | None,
+    odoo_dir: Path | None,
+    database: str | None,
+    keep_clone: bool,
+    no_launcher: bool,
+    extra_args: list[str],
+    cwd: Path,
+    addons_path: list[str] | None = None,
+) -> int:
+    """Main ovx orchestrator. Returns Odoo's exit code."""
+    addon_paths = [p.expanduser().resolve() for p in addon_paths]
+    extra_addons = addons_path or []
+
+    series = get_addon_series(addon_paths[0])
+    for p in addon_paths[1:]:
+        get_addon_series(p)
+
+    resolved = resolve_base_venv(series, venv_dir=venv_dir, cwd=cwd, odoo_dir=odoo_dir)
+
+    target, cleanup = _prepare_target(resolved, addon_paths, series, odoo_dir, keep_clone, extra_addons)
+    try:
+        if not resolved.fresh:
+            all_python_deps: list[str] = []
+            seen: set[str] = set()
+            for p in addon_paths:
+                manifest = ast.literal_eval((p / "__manifest__.py").read_text())
+                for dep in manifest.get("external_dependencies", {}).get("python", []):
+                    if dep not in seen:
+                        seen.add(dep)
+                        all_python_deps.append(dep)
+            union_manifest = {"external_dependencies": {"python": all_python_deps}}
+            missing = install_missing_python_deps(target, union_manifest)
+            if missing:
+                typer.secho(f"Installed missing deps: {', '.join(missing)}", fg=typer.colors.CYAN)
+
+        if not no_launcher:
+            create_launcher(series, target, odoo_dir=odoo_dir, force=False)
+
+        addons_path_parts = _resolve_addons_path(resolved, addon_paths, extra_addons)
+
+        db_name_managed, argv = _build_db_and_argv(target, addon_paths, addons_path_parts, database, extra_args)
+
+        if keep_clone:
+            typer.secho(f"Clone kept at: {target}", fg=typer.colors.YELLOW)
+
+        return run_with_db_lifecycle(argv, db_name_managed)
+
+    finally:
+        if cleanup and not keep_clone:
+            cleanup()
+
+
+def _resolve_addons_path(
+    resolved: ResolvedVenv,
+    addon_paths: list[Path],
+    extra: list[str] | None = None,
+) -> list[str]:
+    """Build the --addons-path list: venv config → extra → each addon's parent, deduped."""
+    parts: list[str] = []
+    if not resolved.fresh and resolved.path is not None:
+        with contextlib.suppress(FileNotFoundError):
+            args, _, _, _ = read_venv_config(resolved.path)
+            stored = args.get("addons_path", "")
+            if stored:
+                parts = [p for p in str(stored).split(",") if p]
+            elif (odoo_dir_str := args.get("odoo_dir", "")) and isinstance(odoo_dir_str, str):
+                odoo_dir = Path(odoo_dir_str)
+                for candidate in [odoo_dir / "addons", odoo_dir / "odoo" / "addons"]:
+                    if candidate.is_dir():
+                        parts.append(str(candidate))
+    parts = parts + (extra or []) + [str(p.parent) for p in addon_paths]
+    return list(dict.fromkeys(parts))
+
+
+def _build_db_and_argv(
+    target: Path,
+    addon_paths: list[Path],
+    addons_path_parts: list[str],
+    database: str | None,
+    extra_args: list[str],
+) -> tuple["str | None", list[str]]:
+    """Determine DB name and build the Odoo argv. Returns (managed_db_name, argv)."""
+    if user_supplied_db(extra_args):
+        db_for_argv = _extract_db_from_args(extra_args) or "odoo"
+        return None, build_odoo_argv(target, addon_paths, addons_path_parts, db_for_argv, extra_args)
+
+    if database:
+        return None, build_odoo_argv(target, addon_paths, addons_path_parts, database, extra_args)
+
+    db_name = make_ephemeral_db_name([p.name for p in addon_paths])
+    return db_name, build_odoo_argv(target, addon_paths, addons_path_parts, db_name, extra_args)
+
+
+def _extract_db_from_args(extra_args: list[str]) -> str | None:
+    """Extract the -d / --database value from extra_args if present."""
+    for i, arg in enumerate(extra_args):
+        if arg in ("-d", "--database") and i + 1 < len(extra_args):
+            return extra_args[i + 1]
+        if arg.startswith("--database="):
+            return arg.split("=", 1)[1]
+    return None

--- a/odoo_venv/ovx_resolver.py
+++ b/odoo_venv/ovx_resolver.py
@@ -1,0 +1,150 @@
+"""Venv resolution and clone primitives for the ovx command."""
+
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from odoo_addons_path import get_odoo_version_from_manifest
+
+from odoo_venv.cli.main import _discover_venvs, _freeze_venv
+from odoo_venv.exceptions import OdooVenvError
+from odoo_venv.utils import read_venv_config
+
+
+@dataclass
+class ResolvedVenv:
+    path: Path | None
+    fresh: bool
+    source: Literal["explicit", "discovered", "fresh"]
+
+
+def get_addon_series(addon_path: Path) -> str:
+    """Return the Odoo major series (e.g. '19.0') for the given addon directory."""
+    if not addon_path.is_dir():
+        raise OdooVenvError(f"Addon path is not a directory: {addon_path}")  # noqa: TRY003
+    manifest_file = addon_path / "__manifest__.py"
+    if not manifest_file.is_file():
+        raise OdooVenvError(f"Missing __manifest__.py in {addon_path}")  # noqa: TRY003
+    series = get_odoo_version_from_manifest(manifest_file)
+    if not series:
+        raise OdooVenvError(  # noqa: TRY003
+            f"Could not determine Odoo series from {addon_path}/__manifest__.py "
+            f"(version must be in form 'X.Y.Z.A.B', e.g. '19.0.1.0.0')"
+        )
+    return series
+
+
+def resolve_base_venv(
+    manifest_series: str,
+    *,
+    venv_dir: Path | None,
+    cwd: Path,
+    odoo_dir: Path | None,
+) -> ResolvedVenv:
+    """Resolve the base venv to use for an ovx run.
+
+    Priority:
+      1. Explicit --venv-dir (must exist and version-match)
+      2. Auto-discover from cwd (exactly one match)
+      3. Fresh-create signal (requires --odoo-dir)
+    """
+    if venv_dir is not None:
+        _, meta, _, _ = read_venv_config(venv_dir)
+        found_version = meta.get("odoo_version", "")
+        if found_version != manifest_series:
+            raise OdooVenvError(  # noqa: TRY003
+                f"Venv at {venv_dir} is for Odoo {found_version}, "
+                f"but addon requires {manifest_series}. "
+                f"Pass a matching --venv-dir or omit it for auto-discovery."
+            )
+        return ResolvedVenv(path=venv_dir, fresh=False, source="explicit")
+
+    discovered = _discover_venvs(cwd)
+    matches = []
+    for venv in discovered:
+        try:
+            _, meta, _, _ = read_venv_config(venv)
+        except FileNotFoundError:
+            continue
+        if meta.get("odoo_version", "") == manifest_series:
+            matches.append(venv)
+
+    if len(matches) == 1:
+        return ResolvedVenv(path=matches[0], fresh=False, source="discovered")
+
+    if len(matches) > 1:
+        paths = ", ".join(str(m) for m in matches)
+        raise OdooVenvError(  # noqa: TRY003
+            f"Found {len(matches)} venvs for Odoo {manifest_series} ({paths}). Pass --venv-dir to disambiguate."
+        )
+
+    # Zero matches
+    if odoo_dir is None:
+        raise OdooVenvError(  # noqa: TRY003
+            f"No venv found for Odoo {manifest_series} in {cwd}. "
+            f"Pass --odoo-dir to create a fresh venv, or --venv-dir to specify one."
+        )
+    return ResolvedVenv(path=None, fresh=True, source="fresh")
+
+
+def clone_venv(base: Path) -> tuple[Path, "Callable[[], None]"]:
+    """Clone *base* venv into a temporary directory.
+
+    Returns ``(clone_path, cleanup_fn)``. The caller must call ``cleanup_fn()``
+    when done (analogous to TemporaryDirectory.__exit__).
+    """
+    tmpdir = tempfile.mkdtemp(prefix="ovx_clone_")
+    clone = Path(tmpdir) / base.name
+
+    # Try copy-on-write first (fast on btrfs/apfs), then plain copy.
+    # We do NOT use -l (hard links) because mutating the clone would mutate the base.
+    result = subprocess.run(  # noqa: S603
+        ["cp", "--reflink=auto", "-r", str(base), str(clone)],  # noqa: S607
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        shutil.copytree(base, clone, symlinks=True)
+
+    _patch_pyvenv_cfg(clone, base)
+
+    def cleanup():
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return clone, cleanup
+
+
+def _patch_pyvenv_cfg(clone: Path, base: Path) -> None:
+    """Rewrite pyvenv.cfg in the clone so it no longer references the base path."""
+    cfg = clone / "pyvenv.cfg"
+    if not cfg.exists():
+        return
+    text = cfg.read_text()
+    # Replace the prompt so it reflects the clone name, not the base name
+    text = text.replace(f"prompt = {base.name}", f"prompt = {clone.name}")
+    cfg.write_text(text)
+
+
+def install_missing_python_deps(clone: Path, manifest: dict) -> list[str]:
+    """Install any python external_dependencies missing from the clone venv.
+
+    Returns the list of packages that were actually installed.
+    """
+    deps: list[str] = manifest.get("external_dependencies", {}).get("python", [])
+    if not deps:
+        return []
+
+    installed = _freeze_venv(clone)
+    missing = [dep for dep in deps if re.sub(r"[-_.]+", "-", dep).lower() not in installed]
+    if not missing:
+        return []
+
+    subprocess.run(  # noqa: S603
+        ["uv", "pip", "install", "--python", str(clone), *missing],  # noqa: S607
+        check=True,
+    )
+    return missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
 
 [project.scripts]
 odoo-venv = "odoo_venv.cli.main:app"
+ovx = "odoo_venv.cli.ovx_cmd:app"
 
 
 [build-system]
@@ -42,7 +43,7 @@ module-root = ""
 build = ["uv ~= 0.7.12"]
 
 [tool.pytest.ini_options]
-norecursedirs = ["tests/fixtures", ".claude"]
+norecursedirs = ["tests/fixtures", "tests/ovx_fixtures", ".claude"]
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]

--- a/site-docs/docs/reference/page-4.md
+++ b/site-docs/docs/reference/page-4.md
@@ -1,0 +1,87 @@
+---
+icon: lucide/zap
+description: "ovx — run an Odoo addon on-the-fly, like npx/uvx but for Odoo."
+tags:
+  - cli
+  - reference
+  - ovx
+  - run
+---
+
+# `ovx`
+
+Run an Odoo addon on-the-fly — like `npx`/`uvx` but for Odoo.
+
+```bash
+ovx ADDON_PATH [OPTIONS] [-- ODOO_ARGS...]
+```
+
+Detects the addon's Odoo series from `__manifest__.py`, resolves or creates a matching venv, installs missing Python dependencies, then runs Odoo with `-i <module>`. The database is ephemeral by default and is dropped on exit.
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ADDON_PATH` | Yes | Path to the Odoo addon directory to run. Must contain `__manifest__.py`. |
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--venv-dir` | — | Explicit venv to use. Must match the addon's Odoo series; error if version mismatches. |
+| `--odoo-dir` | — | Odoo source directory. Required when no matching venv is found (fresh-create path). |
+| `-d`, `--database` | — | Named DB to use. Suppresses ephemeral DB creation and cleanup. |
+| `--no-launcher` | `False` | Skip launcher script creation in `~/.local/bin/`. |
+| `--` | — | Separator: everything after `--` is forwarded verbatim to Odoo. |
+
+## Venv resolution priority
+
+`ovx` resolves the base venv in the following order:
+
+| Priority | Condition | Outcome |
+|----------|-----------|---------|
+| 1 | `--venv-dir` provided | Use it; raise an error if the Odoo version mismatches |
+| 2 | Exactly one venv found under CWD matching the addon's series | Use it |
+| 3 | Multiple matches | Error — pass `--venv-dir` to disambiguate |
+| 4 | No match + `--odoo-dir` provided | Create a fresh venv |
+| 5 | No match, no `--odoo-dir` | Error |
+
+The resolved venv is **cloned** (copy-on-write where supported) before use, so the base venv is never modified.
+
+## Ephemeral DB lifecycle
+
+By default `ovx` generates a unique DB name (`ovx_<addon>_<hex8>`) and drops it when Odoo exits — even on Ctrl-C or non-zero exit.
+
+Pass `-d <name>` to opt out: the named DB is used as-is and is **not** dropped after the run.
+
+## Examples
+
+**Auto-discover a matching venv:**
+
+```bash
+ovx ./crm_eav_fields
+```
+
+**Explicit venv:**
+
+```bash
+ovx ./crm_eav_fields --venv-dir ~/code/foo/.venv
+```
+
+**Fresh-create a venv from Odoo source:**
+
+```bash
+ovx ./crm_eav_fields --odoo-dir ~/code/odoo/19.0
+```
+
+**Named, persistent database:**
+
+```bash
+ovx ./crm_eav_fields -d my_dev_db
+```
+
+**Pass extra arguments through to Odoo:**
+
+```bash
+ovx ./crm_eav_fields -- --log-level=debug --workers 0
+```

--- a/tests/test_ovx.py
+++ b/tests/test_ovx.py
@@ -1,0 +1,628 @@
+"""Unit tests for ovx: addon series detection, venv resolution, clone, argv, DB naming."""
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from odoo_venv.cli.ovx_cmd import app
+from odoo_venv.exceptions import OdooVenvError
+from odoo_venv.ovx import (
+    _resolve_addons_path,
+    build_odoo_argv,
+    make_ephemeral_db_name,
+    run_ovx,
+    run_with_db_lifecycle,
+    user_supplied_db,
+)
+from odoo_venv.ovx_resolver import ResolvedVenv, clone_venv, install_missing_python_deps, resolve_base_venv
+from odoo_venv.utils import write_venv_config
+
+# ---------------------------------------------------------------------------
+# Phase 1 — get_addon_series
+# ---------------------------------------------------------------------------
+
+
+class TestGetAddonSeries:
+    def test_missing_manifest(self, tmp_path):
+        from odoo_venv.exceptions import OdooVenvError
+        from odoo_venv.ovx_resolver import get_addon_series
+
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        with pytest.raises(OdooVenvError, match=r"__manifest__\.py"):
+            get_addon_series(addon)
+
+    def test_not_a_directory(self, tmp_path):
+        from odoo_venv.exceptions import OdooVenvError
+        from odoo_venv.ovx_resolver import get_addon_series
+
+        fake_file = tmp_path / "not_a_dir"
+        fake_file.write_text("x")
+        with pytest.raises(OdooVenvError, match="not a directory"):
+            get_addon_series(fake_file)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — resolve_base_venv
+# ---------------------------------------------------------------------------
+
+
+def _make_venv(path: Path, odoo_version: str) -> Path:
+    """Create a minimal fake odoo-venv directory."""
+    path.mkdir(parents=True, exist_ok=True)
+    write_venv_config(path, {"python_version": "3.10"}, odoo_version=odoo_version)
+    return path
+
+
+class TestResolveBaseVenv:
+    def test_explicit_venv_matching_version(self, tmp_path):
+        venv = _make_venv(tmp_path / ".venv", "19.0")
+        resolved = resolve_base_venv("19.0", venv_dir=venv, cwd=tmp_path, odoo_dir=None)
+        assert resolved.path == venv
+        assert resolved.fresh is False
+        assert resolved.source == "explicit"
+
+    def test_explicit_venv_version_mismatch(self, tmp_path):
+        venv = _make_venv(tmp_path / ".venv", "17.0")
+        with pytest.raises(OdooVenvError, match=r"17\.0"):
+            resolve_base_venv("19.0", venv_dir=venv, cwd=tmp_path, odoo_dir=None)
+
+    def test_discover_single_match(self, tmp_path):
+        _make_venv(tmp_path / ".venv", "19.0")
+        resolved = resolve_base_venv("19.0", venv_dir=None, cwd=tmp_path, odoo_dir=None)
+        assert resolved.path == tmp_path / ".venv"
+        assert resolved.source == "discovered"
+
+    def test_discover_multiple_matches_ambiguous(self, tmp_path):
+        _make_venv(tmp_path / ".venv1", "19.0")
+        _make_venv(tmp_path / ".venv2", "19.0")
+        with pytest.raises(OdooVenvError, match="disambiguate"):
+            resolve_base_venv("19.0", venv_dir=None, cwd=tmp_path, odoo_dir=None)
+
+    def test_discover_no_match_with_odoo_dir(self, tmp_path):
+        odoo_dir = tmp_path / "odoo"
+        odoo_dir.mkdir()
+        resolved = resolve_base_venv("19.0", venv_dir=None, cwd=tmp_path, odoo_dir=odoo_dir)
+        assert resolved.fresh is True
+        assert resolved.source == "fresh"
+        assert resolved.path is None
+
+    def test_discover_no_match_no_odoo_dir(self, tmp_path):
+        with pytest.raises(OdooVenvError, match="--odoo-dir"):
+            resolve_base_venv("19.0", venv_dir=None, cwd=tmp_path, odoo_dir=None)
+
+    def test_version_filter_ignores_wrong_series(self, tmp_path):
+        _make_venv(tmp_path / ".venv", "17.0")
+        # No 19.0 venv found, no odoo_dir → error
+        with pytest.raises(OdooVenvError, match="--odoo-dir"):
+            resolve_base_venv("19.0", venv_dir=None, cwd=tmp_path, odoo_dir=None)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — clone_venv (filesystem-level; no real Python venv needed)
+# ---------------------------------------------------------------------------
+
+
+class TestCloneVenv:
+    def test_clone_produces_copy(self, tmp_path):
+        base = tmp_path / "base_venv"
+        base.mkdir()
+        (base / "pyvenv.cfg").write_text("home = /usr/bin\nprompt = base\n")
+        (base / "bin").mkdir()
+        (base / "bin" / "python").write_text("#!/bin/python\n")
+
+        clone_dir, cleanup = clone_venv(base)
+        try:
+            assert (clone_dir / "pyvenv.cfg").exists()
+            assert (clone_dir / "bin" / "python").exists()
+        finally:
+            cleanup()
+
+    def test_clone_does_not_mutate_base(self, tmp_path):
+        base = tmp_path / "base_venv"
+        base.mkdir()
+        (base / "pyvenv.cfg").write_text("home = /usr/bin\n")
+        original_content = (base / "pyvenv.cfg").read_text()
+
+        clone_dir, cleanup = clone_venv(base)
+        try:
+            # Mutate the clone
+            (clone_dir / "pyvenv.cfg").write_text("home = /mutated\n")
+            # Base must be unchanged
+            assert (base / "pyvenv.cfg").read_text() == original_content
+        finally:
+            cleanup()
+
+    def test_clone_patches_pyvenv_cfg(self, tmp_path):
+        base = tmp_path / "base_venv"
+        base.mkdir()
+        (base / "pyvenv.cfg").write_text("home = /usr/bin\nprompt = base_venv\n")
+
+        clone_dir, cleanup = clone_venv(base)
+        try:
+            cfg = (clone_dir / "pyvenv.cfg").read_text()
+            # prompt should be updated to clone dir name, not base name
+            assert "base_venv" not in cfg or str(clone_dir.name) in cfg
+        finally:
+            cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — install_missing_python_deps
+# ---------------------------------------------------------------------------
+
+
+class TestInstallMissingPythonDeps:
+    @patch("odoo_venv.ovx_resolver.subprocess.run")
+    @patch("odoo_venv.ovx_resolver._freeze_venv", return_value={"requests": "2.31.0"})
+    def test_installs_missing(self, mock_freeze, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0)
+        manifest = {"external_dependencies": {"python": ["requests", "fakepkg"]}}
+        installed = install_missing_python_deps(tmp_path, manifest)
+
+        assert "fakepkg" in installed
+        assert "requests" not in installed
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "fakepkg" in cmd
+
+    @patch("odoo_venv.ovx_resolver.subprocess.run")
+    @patch("odoo_venv.ovx_resolver._freeze_venv", return_value={"requests": "2.31.0", "fakepkg": "1.0"})
+    def test_skips_already_installed(self, mock_freeze, mock_run, tmp_path):
+        manifest = {"external_dependencies": {"python": ["requests", "fakepkg"]}}
+        installed = install_missing_python_deps(tmp_path, manifest)
+
+        assert installed == []
+        mock_run.assert_not_called()
+
+    @patch("odoo_venv.ovx_resolver.subprocess.run")
+    @patch("odoo_venv.ovx_resolver._freeze_venv", return_value={})
+    def test_no_python_deps(self, mock_freeze, mock_run, tmp_path):
+        manifest = {"external_dependencies": {}}
+        installed = install_missing_python_deps(tmp_path, manifest)
+
+        assert installed == []
+        mock_run.assert_not_called()
+
+    @patch("odoo_venv.ovx_resolver.subprocess.run")
+    @patch("odoo_venv.ovx_resolver._freeze_venv", return_value={})
+    def test_no_external_dependencies_key(self, mock_freeze, mock_run, tmp_path):
+        installed = install_missing_python_deps(tmp_path, {})
+        assert installed == []
+        mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — build_odoo_argv
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOdooArgv:
+    def test_basic_argv(self, tmp_path):
+        venv = tmp_path / "venv"
+        addon = tmp_path / "my_addon"
+        addons_path = [str(addon.parent)]
+        db = "testdb"
+
+        argv = build_odoo_argv(venv, [addon], addons_path, db, extra_args=[])
+        assert str(venv / "bin" / "python") == argv[0]
+        assert "-m" in argv
+        assert "odoo" in argv
+        assert "-i" in argv
+        idx = argv.index("-i")
+        assert argv[idx + 1] == "my_addon"
+        assert "--addons-path" in argv
+        assert "-d" in argv
+        idx_d = argv.index("-d")
+        assert argv[idx_d + 1] == db
+
+    def test_extra_args_appended(self, tmp_path):
+        venv = tmp_path / "venv"
+        addon = tmp_path / "my_addon"
+        argv = build_odoo_argv(venv, [addon], [], "testdb", extra_args=["--log-level=debug"])
+        assert "--log-level=debug" in argv
+
+    def test_two_module_argv(self, tmp_path):
+        venv = tmp_path / "venv"
+        parent_a = tmp_path / "src_a"
+        parent_b = tmp_path / "src_b"
+        addon_a = parent_a / "mod_a"
+        addon_b = parent_b / "mod_b"
+        addons_path = [str(parent_a), str(parent_b)]
+
+        argv = build_odoo_argv(venv, [addon_a, addon_b], addons_path, "testdb", extra_args=[])
+        idx_i = argv.index("-i")
+        assert argv[idx_i + 1] == "mod_a,mod_b"
+        idx_ap = argv.index("--addons-path")
+        assert str(parent_a) in argv[idx_ap + 1]
+        assert str(parent_b) in argv[idx_ap + 1]
+
+    def test_user_dash_d_in_extras_detected(self, tmp_path):
+        extra_args = ["-d", "mydb"]
+        assert user_supplied_db(extra_args) is True
+
+    def test_user_database_in_extras_detected(self, tmp_path):
+        assert user_supplied_db(["--database", "mydb"]) is True
+        assert user_supplied_db(["--log-level=debug"]) is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — make_ephemeral_db_name
+# ---------------------------------------------------------------------------
+
+
+class TestMakeEphemeralDbName:
+    def test_max_length(self):
+        name = make_ephemeral_db_name(["a" * 100])
+        assert len(name) <= 63
+
+    def test_uniqueness(self):
+        names = {make_ephemeral_db_name(["addon"]) for _ in range(10)}
+        assert len(names) == 10
+
+    def test_multi_module_joined(self):
+        name = make_ephemeral_db_name(["mod_a", "mod_b"])
+        assert re.match(r"^ovx_mod_a_mod_b_[0-9a-f]{8}$", name), name
+
+    def test_length_cap_multi_module(self):
+        long_names = ["a" * 30, "b" * 30]
+        name = make_ephemeral_db_name(long_names)
+        assert len(name) <= 63
+        assert re.match(r"^ovx_[a-z0-9_]+_[0-9a-f]{8}$", name), name
+
+    def test_single_module(self):
+        name = make_ephemeral_db_name(["my_addon"])
+        assert re.match(r"^ovx_my_addon_[0-9a-f]{8}$", name), name
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — run_with_db_lifecycle
+# ---------------------------------------------------------------------------
+
+
+class FakePopen:
+    def __init__(self, returncode=0):
+        self._rc = returncode
+
+    def wait(self):
+        return self._rc
+
+    def send_signal(self, sig):
+        pass
+
+
+class TestRunWithDbLifecycle:
+    @patch("odoo_venv.ovx.subprocess.run")
+    @patch("odoo_venv.ovx.subprocess.Popen")
+    def test_ephemeral_db_dropped_on_clean_exit(self, mock_popen, mock_run):
+        mock_popen.return_value = FakePopen(0)
+        mock_run.return_value = MagicMock(returncode=0)
+
+        rc = run_with_db_lifecycle(["fake_odoo", "-d", "ovx_test_abc12345"], db_name="ovx_test_abc12345")
+
+        assert rc == 0
+        drop_calls = [c for c in mock_run.call_args_list if "dropdb" in str(c) or "DROP" in str(c)]
+        assert len(drop_calls) >= 1
+
+    @patch("odoo_venv.ovx.subprocess.run")
+    @patch("odoo_venv.ovx.subprocess.Popen")
+    def test_user_supplied_db_not_dropped(self, mock_popen, mock_run):
+        mock_popen.return_value = FakePopen(0)
+        mock_run.return_value = MagicMock(returncode=0)
+
+        rc = run_with_db_lifecycle(["fake_odoo", "-d", "mydb"], db_name=None)
+
+        assert rc == 0
+        drop_calls = [c for c in mock_run.call_args_list if "dropdb" in str(c) or "DROP" in str(c)]
+        assert len(drop_calls) == 0
+
+    @patch("odoo_venv.ovx.subprocess.run")
+    @patch("odoo_venv.ovx.subprocess.Popen")
+    def test_nonzero_exit_still_drops(self, mock_popen, mock_run):
+        mock_popen.return_value = FakePopen(1)
+        mock_run.return_value = MagicMock(returncode=0)
+
+        rc = run_with_db_lifecycle(["fake_odoo", "-d", "ovx_test_abc12345"], db_name="ovx_test_abc12345")
+
+        assert rc == 1
+        drop_calls = [c for c in mock_run.call_args_list if "dropdb" in str(c) or "DROP" in str(c)]
+        assert len(drop_calls) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — _resolve_addons_path with extra paths
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAddonsPath:
+    def _make_resolved_existing(self, tmp_path: Path, stored_paths: list[str]):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        write_venv_config(
+            venv,
+            {"addons_path": ",".join(stored_paths)} if stored_paths else {},
+            odoo_version="17.0",
+        )
+        return ResolvedVenv(path=venv, fresh=False, source="explicit")
+
+    def test_merges_stored_extra_parent(self, tmp_path):
+        resolved = self._make_resolved_existing(tmp_path, ["/a", "/b"])
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        result = _resolve_addons_path(resolved, [addon], extra=["/c"])
+        assert result == ["/a", "/b", "/c", str(addon.parent)]
+
+    def test_dedups_preserving_order(self, tmp_path):
+        resolved = self._make_resolved_existing(tmp_path, ["/a", "/b"])
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        result = _resolve_addons_path(resolved, [addon], extra=["/b", "/c", str(addon.parent)])
+        assert result == ["/a", "/b", "/c", str(addon.parent)]
+        assert result.count("/b") == 1
+        assert result.count(str(addon.parent)) == 1
+
+    def test_fresh_venv_includes_extra_and_addon_parent(self, tmp_path):
+        resolved = ResolvedVenv(path=None, fresh=True, source="fresh")
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        result = _resolve_addons_path(resolved, [addon], extra=["/x"])
+        assert str(addon.parent) in result
+        assert "/x" in result
+
+    def test_addons_path_order_venv_extra_parents(self, tmp_path):
+        resolved = self._make_resolved_existing(tmp_path, ["/venv_stored"])
+        parent_a = tmp_path / "src_a"
+        parent_b = tmp_path / "src_b"
+        addon_a = parent_a / "mod_a"
+        addon_b = parent_b / "mod_b"
+        parent_a.mkdir()
+        parent_b.mkdir()
+        addon_a.mkdir()
+        addon_b.mkdir()
+
+        result = _resolve_addons_path(resolved, [addon_a, addon_b], extra=["/x"])
+        assert result.index("/venv_stored") < result.index("/x")
+        assert result.index("/x") < result.index(str(parent_a))
+        assert result.index(str(parent_a)) < result.index(str(parent_b))
+
+    def test_shared_parent_deduped(self, tmp_path):
+        resolved = self._make_resolved_existing(tmp_path, [])
+        shared = tmp_path / "addons"
+        addon_a = shared / "mod_a"
+        addon_b = shared / "mod_b"
+        shared.mkdir()
+        addon_a.mkdir()
+        addon_b.mkdir()
+
+        result = _resolve_addons_path(resolved, [addon_a, addon_b])
+        assert result.count(str(shared)) == 1
+
+    def test_extra_already_in_venv_config_deduped(self, tmp_path):
+        resolved = self._make_resolved_existing(tmp_path, ["/x"])
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        result = _resolve_addons_path(resolved, [addon], extra=["/x"])
+        assert result.count("/x") == 1
+        assert result.index("/x") == 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — run_ovx with addons_path forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestRunOvxAddonsPath:
+    @patch("odoo_venv.ovx.run_with_db_lifecycle", return_value=0)
+    @patch("odoo_venv.ovx.create_launcher")
+    @patch("odoo_venv.ovx.install_missing_python_deps", return_value=[])
+    @patch("odoo_venv.ovx.clone_venv")
+    @patch("odoo_venv.ovx.resolve_base_venv")
+    @patch("odoo_venv.ovx.get_addon_series", return_value="17.0")
+    def test_extra_addons_appear_in_argv(
+        self,
+        mock_series,
+        mock_resolve,
+        mock_clone,
+        mock_missing,
+        mock_launcher,
+        mock_run,
+        tmp_path,
+    ):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/python")
+        write_venv_config(venv, {}, odoo_version="17.0")
+
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        (addon / "__manifest__.py").write_text('{"name": "T", "version": "17.0.1.0.0"}')
+
+        mock_resolve.return_value = ResolvedVenv(path=venv, fresh=False, source="explicit")
+        mock_clone.return_value = (venv, lambda: None)
+
+        run_ovx(
+            [addon],
+            venv_dir=venv,
+            odoo_dir=None,
+            database="testdb",
+            keep_clone=False,
+            no_launcher=True,
+            extra_args=[],
+            cwd=tmp_path,
+            addons_path=["/extra/path"],
+        )
+
+        called_argv = mock_run.call_args[0][0]
+        addons_path_val = called_argv[called_argv.index("--addons-path") + 1]
+        assert "/extra/path" in addons_path_val
+
+    @patch("odoo_venv.ovx.create_odoo_venv")
+    @patch("odoo_venv.ovx.run_with_db_lifecycle", return_value=0)
+    @patch("odoo_venv.ovx.create_launcher")
+    @patch("odoo_venv.ovx.resolve_base_venv")
+    @patch("odoo_venv.ovx.get_addon_series", return_value="17.0")
+    def test_fresh_venv_receives_all_addons_paths(
+        self,
+        mock_series,
+        mock_resolve,
+        mock_launcher,
+        mock_run,
+        mock_create_venv,
+        tmp_path,
+    ):
+        odoo_dir = tmp_path / "odoo"
+        odoo_dir.mkdir()
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        (addon / "__manifest__.py").write_text('{"name": "T", "version": "17.0.1.0.0"}')
+
+        fresh_venv = tmp_path / "fresh_venv" / "odoo-17.0-venv"
+
+        def fake_create_venv(**kwargs):
+            fresh_venv.mkdir(parents=True, exist_ok=True)
+            (fresh_venv / "bin").mkdir(exist_ok=True)
+            (fresh_venv / "bin" / "python").write_text("#!/bin/python")
+
+        mock_create_venv.side_effect = fake_create_venv
+        mock_resolve.return_value = ResolvedVenv(path=None, fresh=True, source="fresh")
+        mock_run.return_value = 0
+
+        run_ovx(
+            [addon],
+            venv_dir=None,
+            odoo_dir=odoo_dir,
+            database="testdb",
+            keep_clone=True,
+            no_launcher=True,
+            extra_args=[],
+            cwd=tmp_path,
+            addons_path=["/oca/path"],
+        )
+
+        call_kwargs = mock_create_venv.call_args[1]
+        assert str(addon.parent) in call_kwargs["addons_paths"]
+        assert "/oca/path" in call_kwargs["addons_paths"]
+
+    @patch("odoo_venv.ovx.run_with_db_lifecycle", return_value=0)
+    @patch("odoo_venv.ovx.create_launcher")
+    @patch("odoo_venv.ovx.install_missing_python_deps", return_value=[])
+    @patch("odoo_venv.ovx.clone_venv")
+    @patch("odoo_venv.ovx.resolve_base_venv")
+    @patch("odoo_venv.ovx.get_addon_series", return_value="17.0")
+    def test_deps_union_called_once(
+        self,
+        mock_series,
+        mock_resolve,
+        mock_clone,
+        mock_missing,
+        mock_launcher,
+        mock_run,
+        tmp_path,
+    ):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (venv / "bin" / "python").write_text("#!/bin/python")
+        write_venv_config(venv, {}, odoo_version="17.0")
+
+        addon_a = tmp_path / "mod_a"
+        addon_a.mkdir()
+        (addon_a / "__manifest__.py").write_text(
+            '{"name": "A", "version": "17.0.1.0.0", "external_dependencies": {"python": ["requests", "lxml"]}}'
+        )
+        addon_b = tmp_path / "mod_b"
+        addon_b.mkdir()
+        (addon_b / "__manifest__.py").write_text(
+            '{"name": "B", "version": "17.0.1.0.0", "external_dependencies": {"python": ["lxml", "Pillow"]}}'
+        )
+
+        mock_resolve.return_value = ResolvedVenv(path=venv, fresh=False, source="explicit")
+        mock_clone.return_value = (venv, lambda: None)
+
+        run_ovx(
+            [addon_a, addon_b],
+            venv_dir=venv,
+            odoo_dir=None,
+            database="testdb",
+            keep_clone=False,
+            no_launcher=True,
+            extra_args=[],
+            cwd=tmp_path,
+        )
+
+        mock_missing.assert_called_once()
+        called_manifest = mock_missing.call_args[0][1]
+        deps = called_manifest["external_dependencies"]["python"]
+        assert deps == ["requests", "lxml", "Pillow"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — CLI flag parsing in ovx_cmd
+# ---------------------------------------------------------------------------
+
+
+class TestOvxCmdAddonsPathFlag:
+    @patch("odoo_venv.cli.ovx_cmd.run_ovx", return_value=0)
+    def test_csv_parsed_to_resolved_paths(self, mock_run_ovx, tmp_path):
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        (addon / "__manifest__.py").write_text('{"name": "T", "version": "17.0.1.0.0"}')
+
+        extra_a = tmp_path / "extra_a"
+        extra_b = tmp_path / "extra_b"
+        extra_a.mkdir()
+        extra_b.mkdir()
+
+        runner = CliRunner()
+        runner.invoke(app, [str(addon), "--addons-path", f"{extra_a},{extra_b}"])
+
+        assert mock_run_ovx.called
+        kwargs = mock_run_ovx.call_args[1]
+        assert str(extra_a.resolve()) in kwargs["addons_path"]
+        assert str(extra_b.resolve()) in kwargs["addons_path"]
+
+    @patch("odoo_venv.cli.ovx_cmd.run_ovx", return_value=0)
+    def test_no_flag_passes_empty_list(self, mock_run_ovx, tmp_path):
+        addon = tmp_path / "my_addon"
+        addon.mkdir()
+        (addon / "__manifest__.py").write_text('{"name": "T", "version": "17.0.1.0.0"}')
+
+        runner = CliRunner()
+        runner.invoke(app, [str(addon)])
+
+        assert mock_run_ovx.called
+        kwargs = mock_run_ovx.call_args[1]
+        assert kwargs["addons_path"] == []
+
+    @patch("odoo_venv.cli.ovx_cmd.run_ovx", return_value=0)
+    def test_multi_addon_paths_resolved(self, mock_run_ovx, tmp_path):
+        addon_a = tmp_path / "mod_a"
+        addon_b = tmp_path / "mod_b"
+        addon_a.mkdir()
+        addon_b.mkdir()
+        (addon_a / "__manifest__.py").write_text('{"name": "A", "version": "17.0.1.0.0"}')
+        (addon_b / "__manifest__.py").write_text('{"name": "B", "version": "17.0.1.0.0"}')
+
+        runner = CliRunner()
+        runner.invoke(app, [f"{addon_a},{addon_b}"])
+
+        assert mock_run_ovx.called
+        args = mock_run_ovx.call_args[0][0]
+        assert len(args) == 2
+        assert args[0] == addon_a.resolve()
+        assert args[1] == addon_b.resolve()
+
+    @patch("odoo_venv.cli.ovx_cmd.run_ovx", return_value=0)
+    def test_empty_entry_raises_bad_parameter(self, mock_run_ovx, tmp_path):
+        addon = tmp_path / "mod_a"
+        addon.mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(app, [f"{addon},"])
+
+        assert result.exit_code != 0
+        assert not mock_run_ovx.called


### PR DESCRIPTION
## Note
- depends on https://github.com/trobz/odoo-addons-path/pull/15
## Usage

```bash
# Auto-discover matching venv in current directory
ovx ./crm_eav_fields

# Explicit venv (must match addon's Odoo series)
ovx ./crm_eav_fields --venv-dir ~/code/foo/odoo-venv

# Fresh-create a venv from Odoo source
ovx ./crm_eav_fields --odoo-dir ~/code/odoo/19.0

# Use named persistent database (not dropped on exit)
ovx ./crm_eav_fields -d my_dev_db

# Multiple addons in one run
ovx ./addon_a,./addon_b

# Pass extra args to Odoo (after --)
ovx ./crm_eav_fields -- --log-level=debug --workers 0
```

## Summary

Adds `ovx` — a standalone command (like `npx`/`uvx`) that runs Odoo addons instantly without manually managing venvs or databases. Point it at an addon path and it handles series detection, venv resolution, dependency install, and ephemeral DB lifecycle automatically.

## Technical Flow

### Venv Resolution (`ovx_resolver.py`)

| Priority | Condition | Outcome |
|----------|-----------|---------| 
| 1 | `--venv-dir` provided | Use; error if version mismatches |
| 2 | Exactly one venv found under CWD matching series | Use it |
| 3 | Multiple venvs match series | Error — disambiguate with `--venv-dir` |
| 4 | No matches, `--odoo-dir` provided | Fresh-create venv |
| 5 | No matches, no `--odoo-dir` | Error |

### Database Lifecycle

- **Default (ephemeral):** Auto-generated unique name, dropped on exit (even on Ctrl-C)
- **Named (-d):** User-managed, persists, no auto-create/drop