### PR TITLE
fix(assets): update setuptools<82.0.0 to cover odoo's gevent==22.10.2

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -109,10 +109,11 @@ command = ["uv", "pip", "install", "setuptools<82.0"]
 when = "odoo_version > '13.0' and odoo_version <= '17.0'"
 stage = "after_requirements"
 
-# setuptools>=82.0 breaks gevent==22.10.2 which we pin for Python 3.10
+# setuptools>=82.0 breaks gevent==22.10.2 which we pin for Python 3.10 and that odoo pins for Python 3.11
+# It breaks on runtime, as setuptools 82.0.0 removed pkg_resources that gevent 22.10.2 needs
 [[common.extra_commands]]
 command = ["uv", "pip", "install", "setuptools<82.0"]
-when = "odoo_version > '17.0' and python_version == '3.10'"
+when = "odoo_version > '17.0' and python_version >= '3.10' and python_version < '3.12'"
 stage = "after_requirements"
 
 # Install cbor2==5.4.3 for Odoo >= 18.0


### PR DESCRIPTION
In odoo 17.0+, requirements.txt also pin gevent==22.10.2 which needs pkg_resources.

gevent==22.10.2; sys_platform != 'win32' and python_version > '3.10'and python_version < '3.12' # (Jammy)

```
Traceback (most recent call last):
  File "/opt/openerp/openerp-go-a-chau-integration/.venv/bin/odoo", line 3, in <module>
    import odoo.cli
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/cli/__init__.py", line 2, in <module>
    from .command import Command, main  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/cli/command.py", line 8, in <module>
    import odoo.init  # import first for core setup
    ^^^^^^^^^^^^^^^^
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/init.py", line 26, in <module>
    _monkeypatches.patch_init()
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/_monkeypatches/__init__.py", line 62, in patch_init
    HOOK_IMPORT.add_hook(submodule.name)
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/_monkeypatches/__init__.py", line 30, in add_hook
    patch_module(fullname)
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/_monkeypatches/__init__.py", line 67, in patch_module
    module.patch_module()
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/_monkeypatches/site.py", line 16, in patch_module
    patch_evented()
  File "/opt/openerp/openerp-go-a-chau-integration/odoo/odoo/_monkeypatches/site.py", line 34, in patch_evented
    gevent.monkey.patch_all()
  File "/opt/openerp/openerp-go-a-chau-integration/.venv/lib/python3.11/site-packages/gevent/monkey.py", line 1253, in patch_all
    from gevent import events
  File "/opt/openerp/openerp-go-a-chau-integration/.venv/lib/python3.11/site-packages/gevent/events.py", line 74, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```
