### PR TITLE
feat: add list-external-dependencies command

### DIFF
--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -1454,6 +1454,19 @@ def _collect_external_deps_from_manifests(found: dict[str, Path], kind: str) -> 
     return result
 
 
+def _output_raw(deps: dict[str, list[str]]) -> None:
+    by_module: dict[str, list[str]] = {}
+    for pkg, mod_list in deps.items():
+        for mod in mod_list:
+            by_module.setdefault(mod, []).append(pkg)
+    for i, mod in enumerate(sorted(by_module)):
+        typer.echo(f"# {mod}")
+        for pkg in sorted(by_module[mod]):
+            typer.echo(pkg)
+        if i < len(by_module) - 1:
+            typer.echo("")
+
+
 @app.command("list-external-dependencies")
 def list_external_dependencies(
     kind: Annotated[
@@ -1476,10 +1489,22 @@ def list_external_dependencies(
         str | None,
         typer.Option("--project-dir", help="Project directory to auto-detect addons paths from."),
     ] = None,
+    output: Annotated[
+        str,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Output format: `table` (default) or `raw` (grouped by module).",
+        ),
+    ] = "table",
 ):
     """List external dependencies for a set of Odoo modules based on their manifests."""
     from rich import box
     from rich.table import Table
+
+    if output not in ("table", "raw"):
+        typer.secho("error: --output must be 'table' or 'raw'.", fg=typer.colors.RED)
+        raise typer.Exit(1)
 
     if not addons_path and not project_dir:
         typer.secho("error: provide either --addons-path or --project-dir.", fg=typer.colors.RED)
@@ -1506,6 +1531,10 @@ def list_external_dependencies(
 
     if not deps:
         typer.secho(f"No '{kind}' external dependencies found.", fg=typer.colors.YELLOW)
+        return
+
+    if output == "raw":
+        _output_raw(deps)
         return
 
     table = Table(box=box.ROUNDED, show_header=True, header_style="bold cyan")

--- a/odoo_venv/cli/main.py
+++ b/odoo_venv/cli/main.py
@@ -1,3 +1,4 @@
+import ast
 import concurrent.futures
 import json
 import os
@@ -22,7 +23,7 @@ from rich.table import Table
 
 from odoo_venv.exceptions import PresetNotFoundError
 from odoo_venv.launcher import create_launcher
-from odoo_venv.main import create_odoo_venv
+from odoo_venv.main import _resolve_manifest_dep, create_odoo_venv
 from odoo_venv.utils import (
     VENV_CONFIG_FILENAME,
     load_presets,
@@ -1417,6 +1418,102 @@ def show(
     if ignored:
         console.print()
         _print_ignored_panel(console, ignored)
+
+
+def _find_module_manifests(module_names: list[str] | None, addons_path_list: list[str]) -> dict[str, Path]:
+    """Return {module_name: manifest_path} for modules found in addons paths.
+
+    When *module_names* is None, all modules with a manifest are included.
+    """
+    found: dict[str, Path] = {}
+    for addons_dir in addons_path_list:
+        addons_dir_path = Path(addons_dir)
+        if not addons_dir_path.is_dir():
+            continue
+        for module_dir in addons_dir_path.iterdir():
+            if not module_dir.is_dir() or module_dir.name in found:
+                continue
+            if module_names is not None and module_dir.name not in module_names:
+                continue
+            manifest_path = module_dir / "__manifest__.py"
+            if manifest_path.is_file():
+                found[module_dir.name] = manifest_path
+    return found
+
+
+def _collect_external_deps_from_manifests(found: dict[str, Path], kind: str) -> dict[str, list[str]]:
+    """Return {dep: [module_name, ...]} for the given dependency kind from a set of manifest files."""
+    result: dict[str, list[str]] = {}
+    for module_name, manifest_path in found.items():
+        manifest = ast.literal_eval(manifest_path.read_text(encoding="utf-8"))
+        deps = manifest.get("external_dependencies", {}).get(kind, [])
+        if isinstance(deps, list):
+            for dep in deps:
+                entry = _resolve_manifest_dep(dep) if kind == "python" else dep
+                result.setdefault(entry, []).append(module_name)
+    return result
+
+
+@app.command("list-external-dependencies")
+def list_external_dependencies(
+    kind: Annotated[
+        str,
+        typer.Option("--kind", "-k", help="Kind of external dependency, such as `python` or `deb`."),
+    ] = "python",
+    modules: Annotated[
+        str | None,
+        typer.Option(
+            "--modules",
+            "-m",
+            help="Comma-separated list of module names. Defaults to all modules found in the addons path.",
+        ),
+    ] = None,
+    addons_path: Annotated[
+        str | None,
+        typer.Option(help="Comma-separated list of addons paths."),
+    ] = None,
+    project_dir: Annotated[
+        str | None,
+        typer.Option("--project-dir", help="Project directory to auto-detect addons paths from."),
+    ] = None,
+):
+    """List external dependencies for a set of Odoo modules based on their manifests."""
+    from rich import box
+    from rich.table import Table
+
+    if not addons_path and not project_dir:
+        typer.secho("error: provide either --addons-path or --project-dir.", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    if project_dir and not addons_path:
+        addons_path = _detect_project_layout(project_dir)[2]
+
+    if not addons_path:
+        typer.secho("error: could not determine addons path.", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    addons_path_list = [str(Path(p.strip()).expanduser().resolve()) for p in addons_path.split(",")]
+    module_names = [m.strip() for m in modules.split(",") if m.strip()] if modules else None
+
+    found = _find_module_manifests(module_names, addons_path_list)
+
+    if module_names:
+        missing = [m for m in module_names if m not in found]
+        if missing:
+            typer.secho(f"warning: modules not found: {', '.join(missing)}", fg=typer.colors.YELLOW)
+
+    deps = _collect_external_deps_from_manifests(found, kind)
+
+    if not deps:
+        typer.secho(f"No '{kind}' external dependencies found.", fg=typer.colors.YELLOW)
+        return
+
+    table = Table(box=box.ROUNDED, show_header=True, header_style="bold cyan")
+    table.add_column("Package")
+    table.add_column("Required by")
+    for pkg in sorted(deps):
+        table.add_row(pkg, ", ".join(sorted(deps[pkg])))
+    Console().print(table)
 
 
 @app.command("list")

--- a/tests/test_list_external_dependencies.py
+++ b/tests/test_list_external_dependencies.py
@@ -1,0 +1,226 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from odoo_venv.cli.main import (
+    _collect_external_deps_from_manifests,
+    _find_module_manifests,
+    app,
+)
+
+runner = CliRunner()
+
+
+# --- Fixtures ---
+
+
+def _make_module(addons_dir: Path, name: str, python: list[str] | None = None, deb: list[str] | None = None) -> Path:
+    """Create a minimal Odoo module with a manifest under *addons_dir*."""
+    module_dir = addons_dir / name
+    module_dir.mkdir(parents=True, exist_ok=True)
+    ext_deps: dict = {}
+    if python is not None:
+        ext_deps["python"] = python
+    if deb is not None:
+        ext_deps["deb"] = deb
+    manifest = {"name": name, "external_dependencies": ext_deps}
+    (module_dir / "__manifest__.py").write_text(repr(manifest))
+    return module_dir
+
+
+# --- _find_module_manifests ---
+
+
+def test_find_module_manifests_specific_modules(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale")
+    _make_module(addons, "purchase")
+    _make_module(addons, "stock")
+
+    found = _find_module_manifests(["sale", "stock"], [str(addons)])
+
+    assert set(found) == {"sale", "stock"}
+    assert all(p.name == "__manifest__.py" for p in found.values())
+
+
+def test_find_module_manifests_all_modules(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale")
+    _make_module(addons, "purchase")
+
+    found = _find_module_manifests(None, [str(addons)])
+
+    assert set(found) == {"sale", "purchase"}
+
+
+def test_find_module_manifests_skips_dirs_without_manifest(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale")
+    (addons / "not_a_module").mkdir()  # no __manifest__.py
+
+    found = _find_module_manifests(None, [str(addons)])
+
+    assert set(found) == {"sale"}
+
+
+def test_find_module_manifests_first_addons_path_wins(tmp_path):
+    addons1 = tmp_path / "addons1"
+    addons2 = tmp_path / "addons2"
+    _make_module(addons1, "sale")
+    _make_module(addons2, "sale")
+
+    found = _find_module_manifests(["sale"], [str(addons1), str(addons2)])
+
+    assert found["sale"].parent.parent == addons1
+
+
+def test_find_module_manifests_missing_module(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale")
+
+    found = _find_module_manifests(["nonexistent"], [str(addons)])
+
+    assert found == {}
+
+
+def test_find_module_manifests_nonexistent_addons_dir(tmp_path):
+    found = _find_module_manifests(None, [str(tmp_path / "does_not_exist")])
+    assert found == {}
+
+
+# --- _collect_external_deps_from_manifests ---
+
+
+def test_collect_python_deps(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", python=["requests", "stdnum"])
+    found = _find_module_manifests(["sale"], [str(addons)])
+
+    deps = _collect_external_deps_from_manifests(found, "python")
+
+    assert "requests" in deps
+    assert "python-stdnum" in deps  # import-to-pip mapping applied
+    assert deps["requests"] == ["sale"]
+
+
+def test_collect_deb_deps(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", deb=["wkhtmltopdf"])
+    found = _find_module_manifests(["sale"], [str(addons)])
+
+    deps = _collect_external_deps_from_manifests(found, "deb")
+
+    assert deps == {"wkhtmltopdf": ["sale"]}
+
+
+def test_collect_deps_aggregates_modules(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", python=["requests"])
+    _make_module(addons, "purchase", python=["requests", "lxml"])
+    found = _find_module_manifests(None, [str(addons)])
+
+    deps = _collect_external_deps_from_manifests(found, "python")
+
+    assert set(deps["requests"]) == {"sale", "purchase"}
+    assert deps["lxml"] == ["purchase"]
+
+
+def test_collect_deps_empty_when_kind_absent(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", python=["requests"])
+    found = _find_module_manifests(["sale"], [str(addons)])
+
+    deps = _collect_external_deps_from_manifests(found, "deb")
+
+    assert deps == {}
+
+
+def test_collect_deps_no_external_dependencies(tmp_path):
+    addons = tmp_path / "addons"
+    module_dir = addons / "sale"
+    module_dir.mkdir(parents=True)
+    (module_dir / "__manifest__.py").write_text("{'name': 'sale'}")
+    found = _find_module_manifests(["sale"], [str(addons)])
+
+    deps = _collect_external_deps_from_manifests(found, "python")
+
+    assert deps == {}
+
+
+# --- CLI integration ---
+
+
+def test_cli_default_kind_is_python(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", python=["requests"])
+
+    result = runner.invoke(app, ["list-external-dependencies", "--addons-path", str(addons)])
+
+    assert result.exit_code == 0
+    assert "requests" in result.output
+
+
+def test_cli_explicit_kind_deb(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", deb=["wkhtmltopdf"])
+
+    result = runner.invoke(app, ["list-external-dependencies", "--kind", "deb", "--addons-path", str(addons)])
+
+    assert result.exit_code == 0
+    assert "wkhtmltopdf" in result.output
+
+
+def test_cli_filter_by_modules(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", python=["requests"])
+    _make_module(addons, "purchase", python=["lxml"])
+
+    result = runner.invoke(app, ["list-external-dependencies", "--addons-path", str(addons), "--modules", "sale"])
+
+    assert result.exit_code == 0
+    assert "requests" in result.output
+    assert "lxml" not in result.output
+
+
+def test_cli_warns_on_missing_module(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale", python=["requests"])
+
+    result = runner.invoke(
+        app, ["list-external-dependencies", "--addons-path", str(addons), "--modules", "sale,nonexistent"]
+    )
+
+    assert result.exit_code == 0
+    assert "nonexistent" in result.output
+
+
+def test_cli_no_deps_found(tmp_path):
+    addons = tmp_path / "addons"
+    _make_module(addons, "sale")
+
+    result = runner.invoke(app, ["list-external-dependencies", "--addons-path", str(addons)])
+
+    assert result.exit_code == 0
+    assert "No 'python' external dependencies found" in result.output
+
+
+def test_cli_requires_addons_path_or_project_dir():
+    result = runner.invoke(app, ["list-external-dependencies"])
+
+    assert result.exit_code != 0 or "error" in result.output
+
+
+def test_cli_multiple_addons_paths(tmp_path):
+    addons1 = tmp_path / "addons1"
+    addons2 = tmp_path / "addons2"
+    _make_module(addons1, "sale", python=["requests"])
+    _make_module(addons2, "purchase", python=["lxml"])
+
+    result = runner.invoke(
+        app,
+        ["list-external-dependencies", "--addons-path", f"{addons1},{addons2}"],
+    )
+
+    assert result.exit_code == 0
+    assert "requests" in result.output
+    assert "lxml" in result.output


### PR DESCRIPTION
## Summary

- Adds a new `list-external-dependencies` command that reads `external_dependencies.<kind>` from Odoo module manifests and lists the declared packages along with which modules require them
- Works directly from source — no venv needs to exist first
- `--kind` (default: `python`): selects the dependency type (`python`, `deb`, ...)
- `--modules`: optional comma-separated filter; omit to scan all modules found in the addons path
- `--addons-path` or `--project-dir` to locate modules (consistent with the `create` command)
- For `python` deps, the import-to-pip name mapping already used by `create` is applied (e.g. `stdnum` → `python-stdnum`)

Inspired by [`manifestoo list-external-dependencies`](https://github.com/acsone/manifestoo), adapted for our needs.

## Relation to existing commands

The existing `show` command is the closest relative: it displays which pip packages came from manifests, but only after a venv has been created and only for packages that were actually installed. `list-external-dependencies` is complementary — it works on the source directly and answers "what would need to be installed" rather than "what was installed."

## Test plan

- [ ] `odoo-venv list-external-dependencies --addons-path <path>` lists all python deps
- [ ] `--kind deb` lists deb deps
- [ ] `--modules sale,purchase` filters to those modules only
- [ ] Missing module names produce a warning, not an error
- [ ] `--project-dir` auto-detects the addons path
- [ ] 18 unit tests added covering helpers and CLI integration (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)