### PR TITLE
fix(release): upgrade uv in PSR build_command to support exclude-newer relative format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,6 @@ jobs:
         run: |
           git reset --hard ${{ github.sha }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Semantic Version Release
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ norecursedirs = ["tests/fixtures", ".claude"]
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 build_command = """
+  pip install uv --quiet --upgrade
   python -m pip install -e '.[build]'
   uv lock --upgrade-package odoo-venv
   git add uv.lock


### PR DESCRIPTION
## Summary

PSR runs `build_command` inside its own Docker container with a bundled uv too old to parse `exclude-newer = "3 days"` in `uv.toml`. Installing the latest uv via pip at the start of `build_command` puts a modern uv in PATH before the bundled one is invoked.

Fixes: https://github.com/trobz/odoo-venv/actions/runs/27008605636/job/79706352251

## Test plan

- [ ] Release job completes without `TOML parse error` on `uv.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)