### PR TITLE
ci(e2e): fix workflow_dispatch syntax and switch to weekly schedule

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,9 +1,9 @@
 name: e2e
 
 on:
-  workflow_dispatch: True
+  workflow_dispatch:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 19 * * 0"  # Monday 02:00 UTC+7
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/test-action-addon-install-failing.yml
+++ b/.github/workflows/test-action-addon-install-failing.yml
@@ -3,9 +3,17 @@ name: test-action | addon-install-failing
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - action.yml
+      - tests/fixtures/**
+      - .github/workflows/test-action-*.yml
   push:
     branches:
       - main
+    paths:
+      - action.yml
+      - tests/fixtures/**
+      - .github/workflows/test-action-*.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-action-addon-success.yml
+++ b/.github/workflows/test-action-addon-success.yml
@@ -3,9 +3,17 @@ name: test-action | addon-success
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - action.yml
+      - tests/fixtures/**
+      - .github/workflows/test-action-*.yml
   push:
     branches:
       - main
+    paths:
+      - action.yml
+      - tests/fixtures/**
+      - .github/workflows/test-action-*.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-action-addon-tests-failing.yml
+++ b/.github/workflows/test-action-addon-tests-failing.yml
@@ -3,9 +3,17 @@ name: test-action | addon-tests-failing
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - action.yml
+      - tests/fixtures/**
+      - .github/workflows/test-action-*.yml
   push:
     branches:
       - main
+    paths:
+      - action.yml
+      - tests/fixtures/**
+      - .github/workflows/test-action-*.yml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Fix invalid `workflow_dispatch: True` — GitHub requires a bare `workflow_dispatch:` key, causing runs to fail with 0 jobs
- Change e2e schedule from daily to weekly: Monday 02:00 UTC+7 (`0 19 * * 0` UTC)
- Add `paths` filters to all three `test-action` workflows so they only run when `action.yml`, `tests/fixtures/**`, or the workflow files themselves change

## Test plan

- [ ] Verify the e2e workflow can be triggered manually via `gh workflow run e2e.yaml`
- [ ] Confirm next e2e scheduled run fires on Monday 02:00 UTC+7
- [ ] Verify `test-action` workflows skip on unrelated changes and trigger on `action.yml` edits