### PR TITLE
feat(presets): add setproctitle to common preset

### DIFF
--- a/odoo_venv/assets/presets.toml
+++ b/odoo_venv/assets/presets.toml
@@ -95,7 +95,8 @@ gevent==22.10.2; sys_platform == 'linux' and python_version == '3.10',
 greenlet==2.0.2; sys_platform == 'linux' and python_version == '3.10',
 urllib3==1.26.14; python_version > '3.9' and python_version < '3.12',
 psycopg2==2.8.3; sys_platform != 'win32' and python_version < '3.8',
-click-odoo-contrib==1.23.1
+click-odoo-contrib==1.23.1,
+setproctitle
 """
 
 # always ignore those exotic requirements unless explicitely added
@@ -134,7 +135,7 @@ description = """
 
 install_addons_dirs_requirements = true
 install_addons_manifests_requirements = true
-extra_requirement = "debugpy,ipython,setproctitle,watchdog,jingtrang,websocket-client,coverage,pylint-odoo,astroid,pdfminer.six,fonttools"
+extra_requirement = "debugpy,ipython,watchdog,jingtrang,websocket-client,coverage,pylint-odoo,astroid,pdfminer.six,fonttools"
 
 [demo]
 


### PR DESCRIPTION
## Summary
- Move `setproctitle` from the `local`-only preset into `[common]` so it's installed for all presets (local, demo, project, ci), not just local dev venvs.
- Remove the now-redundant `setproctitle` entry from `[local]`'s `extra_requirement`.

## Test plan
- [x] `make check` (lint, format, type-check)
- [x] `make test` (104 passed)