### PR TITLE
fix: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ pip install odoo-venv
 
 ## Quick Start
 
-
 ### 1. Direct CLI Arguments
 
 **Example:**
 
 ```bash
-odoo-venv create 17.0 \
+odoo-venv create \
     --odoo-dir ~/code/odoo/odoo/17.0 \
     --addons-path ~/code/odoo/addons/web,~/code/odoo/addons/mail \
     --python-version 3.10 \
@@ -23,8 +22,8 @@ odoo-venv create 17.0 \
     --extra-requirement "debugpy,ipython"
 ```
 
-This command creates a virtual environment for Odoo 17.0 with the following specifications:
-- Odoo source is located at `~/code/odoo/odoo/17.0`.
+This command creates a virtual environment for Odoo with the following specifications:
+- Odoo source is located at `~/code/odoo/odoo/17.0`. **The Odoo version is auto-detected from `odoo/release.py` inside this directory — there is no separate version argument.**
 - Additional addons are in `~/code/odoo/addons/web` and `~/code/odoo/addons/mail`.
 - The environment uses Python 3.10.
 - It installs dependencies from `requirements.txt` files found in the addons paths.
@@ -37,7 +36,7 @@ The tool includes 4 built-in presets: local, demo, project, ci (see [odoo_venv/a
 **Example:**
 
 ```bash
-odoo-venv create 17.0 \
+odoo-venv create \
     --odoo-dir ~/code/odoo/odoo/17.0 \
     --addons-path ~/code/odoo/addons/web,~/code/odoo/addons/mail \
     --preset demo
@@ -46,7 +45,7 @@ odoo-venv create 17.0 \
 This command will apply all the options from the `demo` preset. You can still override any preset option by providing a direct CLI argument. For example, to use a different `extra_requirement` for a specific run:
 
 ```bash
-odoo-venv create 17.0 \
+odoo-venv create \
     --odoo-dir ~/code/odoo/odoo/17.0 \
     --addons-path ~/code/odoo/addons/web,~/code/odoo/addons/mail \
     --preset demo \


### PR DESCRIPTION
## What

Fixes README examples that no longer match the actual `create` CLI signature.

## Why

All `odoo-venv create` examples in the README show the Odoo version as a positional argument:

    odoo-venv create 17.0 --odoo-dir ...

Running this against the current CLI fails:

    Usage: odoo-venv create [OPTIONS]
    Error: Got unexpected extra argument(s) (17.0)

Looking at `odoo_venv/cli.py`, the `create` command has no `odoo_version` parameter at all — the version is resolved from `odoo/release.py` inside `--odoo-dir` via `_resolve_odoo_dir_and_version()`. Every "Direct CLI Arguments" / "Using Presets" example in the README is currently broken if copy-pasted as-is.

## Changes

- Removed the positional `17.0` from all `odoo-venv create` CLI examples.
- Added a note clarifying that the Odoo version is auto-detected from `--odoo-dir`, not passed on the command line.
- Documented `--project-dir` as an alternative to `--odoo-dir`/`--addons-path` (found in `cli.py`, not previously documented).
- Documented `--skip-on-failure` for packages that fail to build, plus a known limitation: it is not currently forwarded by `ovx` when creating a fresh venv (tracked in #<issue-number>).
- Left the "As a Library" example unchanged — `create_odoo_venv()` does take `odoo_version` explicitly, so that example was already correct.

## Testing

Ran the corrected command against a local Odoo 17.0 checkout on Windows; `odoo-venv create --odoo-dir ... --skip-on-failure` completes successfully. Ran `odoo-venv create --project-dir ...` against a project with a `.trobz/` marker; layout auto-detected correctly.